### PR TITLE
Allow for dynamic binding of instrument

### DIFF
--- a/requirements.md
+++ b/requirements.md
@@ -18,10 +18,10 @@ See also: [SPC Scope](scope.md) for use cases as well as the [issues list](https
 : A mechanism used to transfer value from a payer to a payee.
 
 **SPC Credential** <a name="dfn-spc-credential"></a>
-: Data that represents the association between an instrument and an authentication credential. Note: Management of multiple relationships is an implementation detail (e.g., multiple authentications corresponding to a single instrument, or multiple instruments enrolled for a given authentication).
+: Data that represents the association between an instrument and an authentication credential. Note: Representation of multiple relationships is an implementation detail (e.g., multiple authentications corresponding to a single instrument, or multiple instruments enrolled for a given authentication).
 
 **SPC Credential Identifiers** <a name="dfn-credential-id"></a>
-: Each SPC Credential Identifier refers to one SPC Credential. These identifiers are generated during enrollment and stored by the Relying Party in association with an instrument.
+: Each SPC Credential Identifier refers to one SPC Credential. These identifiers are generated during enrollment and returned by the API to the Relying Party.
 
 **SPC Request** <a name="dfn-spc-request"></a>
 : Information provided as input to the API. It is likely to include
@@ -52,37 +52,45 @@ See also: [SPC Scope](scope.md) for use cases as well as the [issues list](https
 * It is not a requirement that the relying party be able to enroll an [SPC Credential](#dfn-spc-credential) in a third-party context. However, it could improve common payment flows if the relying party could enroll an SPC credential from a cross-origin iframe.
 * It must be possible to enroll an [SPC Credential](#dfn-spc-credential) from a payment handler.
 
+#### Instrument Information at Enrollment
+
+* The Relying Party must not be required to provide definitive
+  information about a specific instrument at enrollment time. In other
+  words, the API supports dynamic binding to a specific instrument at
+  authentication time.
+* It is not a requirement that instrument information be stored in the
+  browser as part of the [SPC Credential](#dfn-spc-credential).
+* The protocol should support multiple ways of accessing the instrument display information, including browser storage and authenticator storage.
+
 #### Enrollment User Experience
 
-* Each browser should natively support an SPC credential enrollment user experience.
+* Each browser should natively support an [SPC Credential](#dfn-spc-credential) enrollment user experience.
 * The user agent should [require and consume at least one transient user activation](https://html.spec.whatwg.org/multipage/interaction.html#activation-consuming-api) in order to display an SPC enrollment user experience.
 * The user should support a user experience of enrollment of multiple instruments for a single authentication. Each resulting [SPC Credential](#dfn-spc-credential) (that is: each instrument/authentication credential binding) must be independently addressable.
 
-#### Instrument Information
+### Payment Confirmation
 
-* Enrollment of an instrument must include display information for it.
-* Because instrument display information is available to the relying party (e.g., provided by the relying party itself, the merchant, or some other party), it is not a requirement that this information be stored in the browser as part of the [SPC Credential](#dfn-spc-credential).
-* The relying party should be able to update the instrument information of an enrolled [SPC Credential](#dfn-spc-credential) (e.g., for new card art).
+#### Instrument Information at Payment Confirmation
 
-### Payment Confirmation User Experience
+* For each [SPC Credential](#dfn-spc-credential), instrument
+  information (e.g., a display string and icon) must be available for
+  use within the payment confirmation user experience.
+* The party that calls the API must be able to provide instrument
+  information for each input SPC Credential Identifier. Note: The
+  Relying Party is the authoritative source of instrument information.
+  If another party provides conflicting instrument information as
+  input to the API, the Relying Party can detect this during
+  subsequent validation.
+
+#### Payment Confirmation User Experience
 
 * Each browser must natively support a payment confirmation user experience.
 * The user agent must [require and consume at least one transient user activation](https://html.spec.whatwg.org/multipage/interaction.html#activation-consuming-api) in order to display an SPC user experience.
 * Although we anticipate that in most cases the browser will render the payment confirmation user experience, the protocol must support rendering by other entities (e.g., the operating system or authenticator).
 * The payment confirmation user experience must display instrument information such as label and icon.
 * The payment confirmation user experience must display amount and currency of the payment.
-* For regulatory reasons, the party that invokes SPC must be able to specify a timeout for the user experience. See [issue 67](https://github.com/w3c/secure-payment-confirmation/issues/67).
+* For regulatory reasons, the party that invokes SPC must be able to specify a timeout for the payment confirmation user experience. See [issue 67](https://github.com/w3c/secure-payment-confirmation/issues/67).
 * The payment confirmation user experience should include the beneficiary name, and optionally the title and favicon of the page where it was called. See [issue 48](https://github.com/w3c/secure-payment-confirmation/issues/48) on merchant information display.
-
-#### Sources of Instrument Information
-
-* The protocol should support multiple ways of accessing the instrument display information, including browser storage, authenticator storage, and merchant-provided data. Note that merchant data may not be trustworthy, but during subsequent
-authorization it can be validated against relying-party stored instrument display data.
-
-#### Cross-Browser Support
-
-* If the user enrolled an [SPC Credential](#dfn-spc-credential) when using one instance of a browser, it should be possible to leverage that authentication from a different instance of the same browser (e.g., both browsers are Firefox)
-* If the user enrolled an [SPC Credential](#dfn-spc-credential) when using one instance of a browser, it should be possible to leverage that authentication from any browser (e.g., one browser is Firefox and the other is Chrome).
 
 #### Levels of User Interaction during Payment Confirmation
 
@@ -94,6 +102,11 @@ authorization it can be validated against relying-party stored instrument displa
 * For each transaction, a merchant should be able to express to the relying
 party a preference to use (or not use) any of the supported levels of user interaction.
 * If the browser supports a low-friction flow option, the browser must support a user preference to override that option and maintain authentication with more user interaction.
+
+#### Cross-Browser Support
+
+* If the user enrolled an [SPC Credential](#dfn-spc-credential) when using one instance of a browser, it should be possible to leverage that authentication from a different instance of the same browser (e.g., both browsers are Firefox)
+* If the user enrolled an [SPC Credential](#dfn-spc-credential) when using one instance of a browser, it should be possible to leverage that authentication from any browser (e.g., one browser is Firefox and the other is Chrome).
 
 ### SPC Credentials
 
@@ -110,6 +123,7 @@ The [SPC Assertion](#dfn-spc-assertion) must include the cryptographic nonce / c
 
 ### Lifecycle Management
 
+* The relying party should be able to update the instrument information of an enrolled [SPC Credential](#dfn-spc-credential) (e.g., for new card art).
 * The user must be able to remove individual [SPC Credentials](#dfn-spc-credential) from a browser instance.
 * The ecosystem should enable the user to communicate to the relying party to forget [SPC Credential Identifiers](#dfn-credential-id). This might happen in a variety of ways (e.g., forget this authenticator and all associated instruments; forget any authenticators associated with this instrument, etc.). See [issue 63](https://github.com/w3c/secure-payment-confirmation/issues/63).
 


### PR DESCRIPTION
Per discussion on 24 May, this edit seeks to support dynamic binding of instruments (at auth time instead of static binding at enrollment time). Also moved around and regrouped existing requirements (improved organization).