### PR TITLE
Remove custom CollectedClientData handling

### DIFF
--- a/spec.bs
+++ b/spec.bs
@@ -610,10 +610,6 @@ directly; for authentication the extension can only be accessed via
          consume a [=transient activation=] here, if we felt the permission policy
          is not sufficient.
 
-    2. In step 13, set the {{CollectedClientData/type}} to "`payment.create`".
-
-        <div class="note">**TODO**: Can we and/or should we rely on `getClientExtensionResults()` instead?</div>
-
 :  Client extension processing ([=authentication extension|authentication=])
 :: When [[webauthn-3#sctn-getAssertion|making an assertion]]:
 


### PR DESCRIPTION
1. Don't set type to payment.create

Given the goal of aligning more closely with WebAuthn the use of `payment.create` instead of `webauthn.create` when creating a new credential seems arbitrary. The data scheme a is the same so there is no need to detect the type.

Also, there is no Auhtenticator extenion processing so no need for authenticators to treat this client data in a special manner.


2. Remove note re getClientExtensionResults

Since the extension defines no "Client extension output" this would always return an empty result (or am I misreading the spec?)