### PR TITLE
Note about credential reuse in both directions

### DIFF
--- a/spec.bs
+++ b/spec.bs
@@ -404,6 +404,11 @@ Note: We currently require an extension in order to allow (1) credential
       and (2) the browser to cache SPC credentials in the absence of
       [=WebAuthn Conditional UI=]. Future versions of this specification may
       remove the requirement for the extension once WebAuthn supports these.
+      As long as SPC depends on the extension, we do not expect that
+      other types of WebAuthn credentials will be usable with SPC. On the
+      other hand, one may be able to use SPC credentials in other
+      contexts (e.g., for login), but such reuse lies outside the scope
+      of this specification.
 
 # Authentication # {#sctn-authentication}
 

--- a/spec.bs
+++ b/spec.bs
@@ -398,16 +398,15 @@ To enroll a user for Secure Payment Confirmation, relying parties should call
 {{AuthenticationExtensionsClientInputs/payment}} [=WebAuthn Extension=]
 specified.
 
-Note: We currently require an extension in order to allow (1) credential
-      creation in a cross-origin iframe (which WebAuthn does not yet allow)
-      and (2) the browser to cache SPC credentials in the absence of
-      [=WebAuthn Conditional UI=]. Future versions of this specification may
-      remove the requirement for the extension once WebAuthn supports these.
-      As long as SPC depends on the extension, we do not expect that
-      other types of WebAuthn credentials will be usable with SPC. On the
-      other hand, one may be able to use SPC credentials in other
-      contexts (e.g., for login), but such reuse lies outside the scope
-      of this specification.
+Note: In this specification we define an extension in order to allow
+      (1) credential creation in a cross-origin iframe (which WebAuthn
+      does not yet allow) and (2) the browser to cache SPC credentials
+      in the absence of [=WebAuthn Conditional UI=]. If these
+      capabilities are available in future versions of WebAuthn, we
+      may remove the requirement for the extension from SPC. Note that
+      SPC credentials (with the extension) are otherwise full-fledged
+      WebAuthn credentials. This specification does not preclude their
+      use in other use-cases (e.g., login).
 
 # Authentication # {#sctn-authentication}
 


### PR DESCRIPTION
This pull request comes from an issue raised by @Goosth [1] and discussed at today's SPC task force call.

[1] https://github.com/w3c/secure-payment-confirmation/pull/103


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/secure-payment-confirmation/pull/104.html" title="Last updated on Aug 20, 2021, 2:53 PM UTC (4c5e898)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/secure-payment-confirmation/104/44ef82b...4c5e898.html" title="Last updated on Aug 20, 2021, 2:53 PM UTC (4c5e898)">Diff</a>