### PR TITLE
Registration instead of Enrollment

### DIFF
--- a/explainer.md
+++ b/explainer.md
@@ -37,7 +37,7 @@ See also:
   - [Traditional WebAuthn](#traditional-webauthn)
   - [Delegated Authentication](#delegated-authentication)
 - [Security Considerations](#security-considerations)
-  - [Enrollment in cross-origin iframes](#enrollment-in-cross-origin-iframes)
+  - [Registration in cross-origin iframes](#registration-in-cross-origin-iframes)
   - [Cross-origin authentication ceremony](#cross-origin-authentication-ceremony)
   - [Merchant-supplied data](#merchant-supplied-data)
 - [Privacy Considerations](#privacy-considerations)
@@ -89,7 +89,7 @@ authentication problem, as:
    cannot be used as-is to fulfill regulatory requirements to provide evidence
    of user content (e.g. [Dynamic Linking] requirements).
 1. WebAuthn does not allow credential creation in a cross-origin iframe, thus
-   excluding a useful onboarding flow - enrolling a Customer after they have
+   excluding a useful onboarding flow - registering a Customer after they have
    completed a traditional authentication flow (e.g. via SMS OTP), without
    the friction of redirecting them to the bank's site or app.
 
@@ -113,14 +113,14 @@ Find a solution that (in no particular order):
 > to e.g. Dynamic Linking, but we aim to produce a solution that could be
 > vetted as such.
 
-* Allows for in-flow enrollment of Customers during a traditional challenge
+* Allows for in-flow registration of Customers during a traditional challenge
   flow, as well as outside of a transaction.
 
 ### Non-Goals
 
 * Selection of a Payment Instrument by the Customer; it is presumed that the
   Customer has already done so (e.g. by typing in their credit card number).
-* ID & V to establish real world identity during enrollment; it is up to the
+* ID & V to establish real world identity during registration; it is up to the
   Account Provider to determine the Customer's identity to their satisfaction.
 * Providing authentication for peer-to-peer or business-to-business
   transactions.
@@ -133,7 +133,7 @@ Secure Payment Confirmation (SPC) builds on top of [WebAuthn] to add
 payment-specific data to the signed assertion, and to relax assumptions to
 allow the API to be called in payment contexts.
 
-Ideally with Secure Payment Confirmation, a Customer would enroll once on a
+Ideally with Secure Payment Confirmation, a Customer would register once on a
 given device for a given account with an Account Provider, either on the
 Account Provider's website or during a traditionally-authenticated online
 payment (e.g. after completing a challenge in a Account Provider iframe). Then,
@@ -249,7 +249,7 @@ navigator.credentials.create({ publicKey })
   });
 ```
 
-As per the above note, the need to have a special enrollment flow for SPC will
+As per the above note, the need to have a special registration (formerly "enrollment") flow for SPC will
 depend on whether:
 
 * [WebAuthn] starts to allow credential creation in a cross-origin iframe.
@@ -257,13 +257,13 @@ depend on whether:
    in SPC authentication.
 
 If both of these become true, then the extension would not be needed during
-enrollment.
+registration.
 
 ##### Creating a SPC credential in a cross-origin iframe
 
 Unlike normal WebAuthn credentials, SPC allows a credential to be created in a
 cross-origin iframe (e.g. if `merchant.com` embeds an iframe from `bank.com`). This is
-intended to support the common enrollment flow of a bank enrolling the user during a
+intended to support the common registration flow of a bank registering the user during a
 step-up challenge (e.g. after proving their identity via OTP).
 
 To allow this, the cross-origin iframe must have the ["payment" permission
@@ -362,7 +362,7 @@ merchants that accept credit cards.
 
 ## Security Considerations
 
-### Enrollment in cross-origin iframes
+### Registration in cross-origin iframes
 
 ### Cross-origin authentication ceremony
 

--- a/requirements.md
+++ b/requirements.md
@@ -18,12 +18,12 @@ See also: [SPC Scope](scope.md) for use cases as well as the [issues list](https
 : A mechanism used to transfer value from a payer to a payee.
 
 **SPC Credential Identifiers** <a name="dfn-credential-id"></a>
-: These identifiers are generated during enrollment and returned by the API to the Relying Party. The Relying Party is the authoritative source for the meaning of each identifier (e.g., whether it refers to a user account, a specific instrument, or something else). It is the responsibility of the Relying Party to
+: These identifiers are generated during registration (formerly "enrollment") and returned by the API to the Relying Party. The Relying Party is the authoritative source for the meaning of each identifier (e.g., whether it refers to a user account, a specific instrument, or something else). It is the responsibility of the Relying Party to
 communicate clearly to the user what the user is consenting to during
-an [SPC Enrollment](#dfn-spc-enrollment). The Relying Party determines whether it is satisfied with a given [SPC Assertion](#dfn-spc-assertion) for a given use case.
+an [SPC Registration](#dfn-spc-registration). The Relying Party determines whether it is satisfied with a given [SPC Assertion](#dfn-spc-assertion) for a given use case.
 
-**SPC Enrollment** <a name="dfn-spc-enrollment"></a>
-: The process of generating an SPC Credential Identifier for a Relying party. Enrollment may optionally involve other activities (e.g., browsers may choose to store other information in conjunction with the SPC Credential Identifier).
+**SPC Registration** <a name="dfn-spc-registration"></a>
+: The process of generating an SPC Credential Identifier for a Relying party. Registration may optionally involve other activities (e.g., browsers may choose to store other information in conjunction with the SPC Credential Identifier).
 
 **SPC Request** <a name="dfn-spc-request"></a>
 : Information provided as input to the API to generate an SPC Assertion. It is likely to include [SPC Credential Identifiers](#dfn-credential-id), instrument information such as a string and icon, sources of randomness, and other data.
@@ -46,29 +46,29 @@ an [SPC Enrollment](#dfn-spc-enrollment). The Relying Party determines whether i
 * It must be possible to call SPC from a Web site or a payment handler. Note: This implies changes to the Payment Handler API are likely.
 * Because many checkout experiences are offered through iframes, it must be possible to call SPC from an iframe. SPC usage within an iframe must be enabled through a permission policy. See [issue 68](https://github.com/w3c/secure-payment-confirmation/issues/68).
 
-### Enrollment
+### Registration
 
-* It must be possible to do an [SPC Enrollment](#dfn-spc-enrollment) outside of a transaction.
-* It must be possible to do an [SPC Enrollment](#dfn-spc-enrollment) following a prior (non-SPC) authentication during a transaction. This enrollment should not prevent timely completion of the transaction.
-* It is not a requirement that the relying party be able to do an [SPC Enrollment](#dfn-spc-enrollment) in a third-party context. However, it could improve common payment flows if the relying party could enroll from a cross-origin iframe.
-* It must be possible to do an [SPC Enrollment](#dfn-spc-enrollment) from a payment handler.
+* It must be possible to do an [SPC Registration](#dfn-spc-registration) outside of a transaction.
+* It must be possible to do an [SPC Registration](#dfn-spc-registration) following a prior (non-SPC) authentication during a transaction. This registration should not prevent timely completion of the transaction.
+* It is not a requirement that the relying party be able to do an [SPC Registration](#dfn-spc-registration) in a third-party context. However, it could improve common payment flows if the relying party could register from a cross-origin iframe.
+* It must be possible to do an [SPC Registration](#dfn-spc-registration) from a payment handler.
 
-#### Instrument Information at Enrollment
+#### Instrument Information at Registration
 
 * The Relying Party must not be required to provide definitive
-  information about a specific instrument at enrollment time. In other
+  information about a specific instrument at registration time. In other
   words, the API supports dynamic binding to a specific instrument at
   authentication time. This feature renders unnecessary additional
   functionality to update browser-stored instrument information.
 * It is not a requirement that instrument information be stored in the
-  browser as part of an [SPC Enrollment](#dfn-spc-enrollment).
+  browser as part of an [SPC Registration](#dfn-spc-registration).
 * The protocol should support multiple ways of accessing the instrument display information, including browser storage and authenticator storage.
 
-#### Enrollment User Experience
+#### Registration User Experience
 
-* Each browser should natively support an [SPC Enrollment](#dfn-spc-enrollment)  user experience.
-* The user agent should [require and consume at least one transient user activation](https://html.spec.whatwg.org/multipage/interaction.html#activation-consuming-api) in order to display an SPC enrollment user experience.
-* The party that invokes SPC enrollment must be able to specify a timeout for the enrollment user experience.
+* Each browser should natively support an [SPC Registration](#dfn-spc-registration)  user experience.
+* The user agent should [require and consume at least one transient user activation](https://html.spec.whatwg.org/multipage/interaction.html#activation-consuming-api) in order to display an SPC registration user experience.
+* The party that invokes SPC registration must be able to specify a timeout for the registration user experience.
 
 
 ### Payment Confirmation
@@ -112,13 +112,13 @@ party a preference to use (or not use) any of the supported levels of user inter
 
 #### Cross-Browser Support
 
-* If the user did an [SPC Enrollment](#dfn-spc-enrollment) when using one instance of a browser, it should be possible to leverage that authentication from a different instance of the same browser (e.g., both browsers are Firefox)
-*If the user did an [SPC Enrollment](#dfn-spc-enrollment) when using one instance of a browser, it should be possible to leverage that authentication from any browser (e.g., one browser is Firefox and the other is Chrome). Note:  [Large Blob](https://www.w3.org/TR/webauthn-2/#sctn-large-blob-extension) (WebAuthn Level 2) may be used to create portable stored data to reduce the total number of enrollments.
+* If the user did an [SPC Registration](#dfn-spc-registration) when using one instance of a browser, it should be possible to leverage that authentication from a different instance of the same browser (e.g., both browsers are Firefox)
+*If the user did an [SPC Registration](#dfn-spc-registration) when using one instance of a browser, it should be possible to leverage that authentication from any browser (e.g., one browser is Firefox and the other is Chrome). Note:  [Large Blob](https://www.w3.org/TR/webauthn-2/#sctn-large-blob-extension) (WebAuthn Level 2) may be used to create portable stored data to reduce the total number of registrations.
 
 ### SPC Credential Identifiers and Matching
 
 * It it left to the user agent how the user selects an authentication path when more than one matches the [SPC Request](#dfn-spc-request). See [issue 69](https://github.com/w3c/secure-payment-confirmation/issues/69) for discussion.
-* When the user agent has no information matching the [SPC Request](#dfn-spc-request), for privacy reasons the browser may inform the user that the API has been invoked but failed. Note: Whoever might call the API can determine in advance that the user has never done an [SPC Enrollment](#dfn-spc-enrollment), and choose not to call the API.
+* When the user agent has no information matching the [SPC Request](#dfn-spc-request), for privacy reasons the browser may inform the user that the API has been invoked but failed. Note: Whoever might call the API can determine in advance that the user has never done an [SPC Registration](#dfn-spc-registration), and choose not to call the API.
 
 ### SPC Assertions
 

--- a/scope.md
+++ b/scope.md
@@ -33,7 +33,7 @@ offering a predictable user experience across sites, and avoiding
 redirects.
 
 * **Scalable and Ubiquitous**. SPC supports streamlined authentication
-across multiple merchant sites following a single enrollment.
+across multiple merchant sites following a single registration.
 
 * **Designed to Meet Regulatory Requirements**. The standardized
 payment confirmation user experience is designed to help entities
@@ -87,42 +87,42 @@ This list is the result of people joining the SPC task force:
 
 #### Authentication different merchant
 
-* Having enrolled an authenticator previously with her bank (e.g., while mobile banking or during a transaction on any merchant site), Alice is shopping on an unrelated merchant
+* Having registered an authenticator previously with her bank (e.g., while mobile banking or during a transaction on any merchant site), Alice is shopping on an unrelated merchant
 site.
-* During checkout, Alice selects the same instrument and is prompted (e.g., during an EMV&reg; 3-D Secure step up) to authenticate by using the enrolled authenticator.
+* During checkout, Alice selects the same instrument and is prompted (e.g., during an EMV&reg; 3-D Secure step up) to authenticate by using the registered authenticator.
 
-#### In-transaction enrollment, later authentication same merchant
+#### In-transaction registration, later authentication same merchant
 
 * While checking out, Alice selects an instrument and is successfully authenticated by her bank via one-time password, Web Authentication, or other means.
 * She is then prompted with the opportunity to speed up future checkouts by
-enrolling her authenticator with her bank and associating it with the same instrument.
-* A few days later during checkout on the same merchant site, Alice is prompted (e.g., during an EMV&reg; 3-D Secure step up) to confirm a payment with the same instrument by using the enrolled authenticator.
+registering her authenticator with her bank and associating it with the same instrument.
+* A few days later during checkout on the same merchant site, Alice is prompted (e.g., during an EMV&reg; 3-D Secure step up) to confirm a payment with the same instrument by using the registered authenticator.
 
-Note: This use case intends to capture the "in-transaction enrollment" use case. We also expect to support enrollment independent of a transaction.
+Note: This use case intends to capture the "in-transaction registration" use case. We also expect to support registration independent of a transaction.
 
-#### Enrollment of multiple instruments with one authentication
+#### Registration of multiple instruments with one authentication
 
-* While mobile banking, Alice enrolls her authenticator to be used with all her credit cards issued by this bank.
+* While mobile banking, Alice registers her authenticator to be used with all her credit cards issued by this bank.
 * A few days later during checkout, Alice is prompted to confirm a transaction with one of those cards via her authenticator.
 
 #### Association of new instrument with existing authentication credential
 
-* While visiting her bank site, Alice enrolls her authenticator in association with two instruments.
+* While visiting her bank site, Alice registers her authenticator in association with two instruments.
 * The following week she associates a third instrument with the same authentication credential.
 
 #### EMV&reg; Secure Remote Commerce (SRC) System as Relying Party
 
 * Alice checkouts on a merchant web site with SRC, which triggers the SRC Digital Card Facilitator (DCF) to be displayed. The SRC DCF asks whether she wants to use biometric authentication to streamline payment. She agrees and SRC DCF redirects her to her bank where she goes through an ID&V process with her bank for the credit card she wishes to use.
-* As an alternative, Alice visits her bank, authenticates to her bank, enrolls into biometric authentication, and selects card(s) that she wants to make available to SRC. The bank (the Relying Party) shares the authentication credential with the SRC System.
+* As an alternative, Alice visits her bank, authenticates to her bank, registers into biometric authentication, and selects card(s) that she wants to make available to SRC. The bank (the Relying Party) shares the authentication credential with the SRC System.
 * The following week Alice checkouts with a merchant enabled with SRC. The SRCi/DCF prompts Alice to do biometric authentication. The SRC System reviews the authentication results, and the bank authorizes the transaction.
 
 Note: We anticipate that flows of "SPC with 3DS" and "SPC with SRC" will be similar, but with different entities as Relying Party.
 
 ### Lower Priority
 
-#### Enrollment for both payment authentication and account login
+#### Registration for both payment authentication and account login
 
-* During a guest checkout experience, Alice selects an instrument. As part of authenticating, she enrolls her authenticator with her bank in association with the instrument.
+* During a guest checkout experience, Alice selects an instrument. As part of authenticating, she registers her authenticator with her bank in association with the instrument.
 * In addition, Alice is prompted to set up a user account with this particular merchant, leveraging the same authentication credentials.
 * The goal is thus to enable Alice to use the same authentication credential to (1) make payments on multiple sites, and (2) log into this site.
 
@@ -134,7 +134,7 @@ Notes:
 
 This use cases is like the previous authentication use cases (same merchant or different merchant) but removes the user presence check. Because doing so removes a security feature, we suggest native browser UX as a way to help ensure that the user has not been tricked into agreeing to less friction.
 
-* Alice is prompted to enroll her authenticator during a transaction on a merchant site.
+* Alice is prompted to register her authenticator during a transaction on a merchant site.
 * Through a browser-native UX, Alice selects the "express checkout" option for this merchant. The browser does not share this user preference with any party.
 * During a future checkout on the same merchant site, the Alice clicks the "Buy" button.
 * The merchant communicates a preference for express checkout for this transaction. The Payment Service Provider conveys this preference to the Relying Party
@@ -164,7 +164,7 @@ customer, payment amount, regulatory requirements, etc.
 This use cases is like the Express Checkout use case except that, in
 addition, there is no browser-supplied confirmation dialog.
 
-* Alice is prompted to enroll her authenticator during a transaction on a merchant site.
+* Alice is prompted to register her authenticator during a transaction on a merchant site.
 * Through a browser-native UX, Alice selects the "frictionless checkout" option for this merchant. The browser does not share this user preference with any party.
 * During a future checkout on the same merchant site, the user clicks the "Buy" button.
 * The merchant communicates a preference for frictionless checkout for this transaction. The Payment Service Provider conveys this preference to the Relying Party when seeking SPC Payment Identifiers.
@@ -182,7 +182,7 @@ Notes:
 
 ### Additional Considerations
 
-These use cases represent additional considerations, some of which (e.g., unenrollment) may be orthogonal to the primary flows above. 
+These use cases represent additional considerations, some of which (e.g., unregistration) may be orthogonal to the primary flows above. 
 
 #### Merchant as Relying Party
 
@@ -193,11 +193,11 @@ These use cases represent additional considerations, some of which (e.g., unenro
 
 #### Authentication by Relying Party after redirect
 
-* Alice has enrolled her authenticator with a Relying Party (e.g. her bank)
+* Alice has registered her authenticator with a Relying Party (e.g. her bank)
 * While Alice is shopping on a merchant site, the merchant redirects her to the Relying Party site to authenticate.
-* The Relying Party invokes SPC using the previously enrolled authenticator.
+* The Relying Party invokes SPC using the previously registered authenticator.
 
-#### Authenticator unenrollment
+#### Authenticator unregistration
 
 * Alice drops her phone in the river.
 * For housekeeping, she logs into her bank site and removes information about the authenticator. This causes the bank to remove any bindings between that authenticator and any instruments.
@@ -220,7 +220,7 @@ priority:
 
 ## Out of Scope
 
-* ID & V to establish real world identity during enrollment.
+* ID & V to establish real world identity during registration.
 * Use cases for peer-to-peer payments or business-to-business transactions.
 
 ## Future Extensions

--- a/spec.bs
+++ b/spec.bs
@@ -72,14 +72,15 @@ methods in payment flows on the web. It aims to provide the same authentication
 benefits and user privacy focus as [[webauthn-3]] with enhancements to meet the needs of payment processing.
 
 Similarly to [[webauthn-3]], this specification defines two related
-processes involving a user. The first is [[#sctn-enrollment]], where a
-relationship is created between the user and the [=Relying
-Party=]. The second is [[#sctn-authentication]], where the user
-responds to a challenge from the [=Relying Party=] (possibly via an
-intermediary payment service provider) to consent to a specific
-payment. An important feature of Secure Payment Confirmation is that
-the merchant (or another entity) may initiate the authentication
-ceremony on the [=Relying Party's=] behalf.
+processes involving a user. The first is [[#sctn-registration]]
+(formerly "enrollment"), where a relationship is created between the
+user and the [=Relying Party=]. The second is
+[[#sctn-authentication]], where the user responds to a challenge from
+the [=Relying Party=] (possibly via an intermediary payment service
+provider) to consent to a specific payment. An important feature of
+Secure Payment Confirmation is that the merchant (or another entity)
+may initiate the authentication ceremony on the [=Relying Party's=]
+behalf.
 
 Functionally, this specification defines a new [=payment method=] for the
 {{PaymentRequest}} API, and adds a [=WebAuthn Extension=] to extend
@@ -139,7 +140,7 @@ These limitations motivate the following Secure Payment Confirmation behaviors:
     other Web features. The current specification is designed to
     increase the security and usability of Web payments.
 
-### Enrollment in a third-party iframe ### {#sctn-use-case-iframe-enrollment}
+### Registration in a third-party iframe ### {#sctn-use-case-iframe-registration}
 
 If a bank wishes to use [[webauthn-3]] as the [=Relying Party=], that
 specification requires the bank to register the user in a first party
@@ -150,7 +151,7 @@ payment journey creates a risk of transaction abandonment.
 
 This limitation motivates the following Secure Payment Confirmation behavior:
 
-1. SPC supports cross-origin enrollment from an iframe in a third-party context. For instance, this enrollment might take place following some other ID&V flow (e.g., SMS OTP).
+1. SPC supports cross-origin registration from an iframe in a third-party context. For instance, this registration might take place following some other ID&V flow (e.g., SMS OTP).
 
 * See <a href="https://github.com/w3c/webauthn/issues/1336#issuecomment-554170183">discussion on WebAuthn issue 1336</a>.
 
@@ -181,7 +182,7 @@ In this section, we walk through some scenarios for Secure Payment Confirmation
 and the corresponding sample code for using this API. Note that these are
 example flows and do not limit the scope of how the API can be used.
 
-### Enrollment ### {#sctn-sample-enrollment}
+### Registration ### {#sctn-sample-registration}
 
 This is the first-time flow, in which a new credential is created and stored by
 an issuing bank.
@@ -200,9 +201,9 @@ an issuing bank.
 
 1. In the iframe, the issuing bank confirms the user's identity via a
     traditional means (e.g., SMS OTP). After confirmation, the
-    bank invites the user to enroll in SPC authentication for future payments.
+    bank invites the user to register in SPC authentication for future payments.
 
-1. The user consents (e.g., by clicking an "Enroll" button in the bank UX), and
+1. The user consents (e.g., by clicking an "Register" button in the bank UX), and
     the bank runs code in the iframe (see example below).
 
 1. The user goes through a WebAuthn registration flow. A new
@@ -213,9 +214,9 @@ an issuing bank.
 1. The verification completes; the bank iframe closes and the merchant finishes
     the checkout process for the user.
 
-The sample code for enrolling the user follows:
+The sample code for registering the user follows:
 
-<pre class="example" id="enrollment-example" highlight="js">
+<pre class="example" id="registration-example" highlight="js">
 if (!window.PublicKeyCredential) { /* Client not capable. Handle error. */ }
 
 const publicKey = {
@@ -290,7 +291,7 @@ Payment Confirmation.
     indicate that they wish to pay (e.g., by pressing a "Pay" button).
 
     Note: The cross-origin use of SPC credentials makes it possible for
-    the user to "enroll once" and authenticate on any merchant origin,
+    the user to "register once" and authenticate on any merchant origin,
     not just the merchant origin where the user first registered for SPC.
 
 1. The merchant communicates out-of-band
@@ -391,9 +392,9 @@ below and in [[#index-defined-elsewhere]].
     improve feature detection, invocation, and other aspects of the
     API.</div>
 
-# Enrollment # {#sctn-enrollment}
+# Registration # {#sctn-registration}
 
-To enroll a user for Secure Payment Confirmation, relying parties should call
+To register a user for Secure Payment Confirmation, relying parties should call
 {{CredentialsContainer/create()|navigator.credentials.create()}}, with the
 {{AuthenticationExtensionsClientInputs/payment}} [=WebAuthn Extension=]
 specified.
@@ -472,7 +473,7 @@ members:
     :: The list of credential identifiers for the given instrument.
 
     :  <dfn>instrument</dfn> member
-    :: The description of the instrument name and icon to display during enrollment and to be signed along with the transaction details.
+    :: The description of the instrument name and icon to display during registration and to be signed along with the transaction details.
 
     :  <dfn>timeout</dfn> member
     :: The number of milliseconds before the request to sign the transaction details times out. At most 1 hour.
@@ -481,7 +482,7 @@ members:
     :: The fully qualified [=origin=] of the payee that this SPC call is for (e.g., the merchant).
 
     :  <dfn>extensions</dfn> member
-    :: Any [=WebAuthn extensions=] that should be used for the passed credential(s). The caller does not need to specify the [[#sctn-payment-extension-enrollment| payment extension]]; it is added automatically.
+    :: Any [=WebAuthn extensions=] that should be used for the passed credential(s). The caller does not need to specify the [[#sctn-payment-extension-registration| payment extension]]; it is added automatically.
 </dl>
 
 ### Steps to check if a payment can be made ### {#sctn-steps-to-check-if-a-payment-can-be-made}
@@ -567,7 +568,7 @@ The [=steps to respond to a payment request=] for this payment method, for a giv
 
 1. Return |outputCredential|.
 
-# WebAuthn Extension - "`payment`" # {#sctn-payment-extension-enrollment}
+# WebAuthn Extension - "`payment`" # {#sctn-payment-extension-registration}
 
 This [=client extension|client=] [=registration extension=] and
 [=authentication extension=] indicates that a credential is either being
@@ -735,7 +736,7 @@ frame is already included in {{CollectedClientData}} of [[webauthn-3]].
 
 # Common Data Structures # {#sctn-common-data-structures}
 
-The following data structures are shared between enrollment and authentication.
+The following data structures are shared between registration and authentication.
 
 ## <dfn dictionary>PaymentCredentialInstrument</dfn> Dictionary ## {#sctn-paymentcredentialinstrument-dictionary}
 
@@ -762,7 +763,7 @@ contains the following members:
 
 This specification uses the "[=payment permission string|payment=]"
 policy-identifier string from [[payment-request]] to control access to **both**
-enrollment and authentication. This extends the
+registration and authentication. This extends the
 [[webauthn-3#sctn-permissions-policy|WebAuthn Permission Policy]].
 
 Note: Algorithms specified in [[!CREDENTIAL-MANAGEMENT-1]] perform the actual permissions policy evaluation. This is because such policy evaluation needs to occur when there is access to the [=current settings object=]. The {{PublicKeyCredential/[[Create]](origin, options, sameOriginWithAncestors)}} and {{PublicKeyCredential/[[DiscoverFromExternalSource]](origin, options, sameOriginWithAncestors)}} [=internal methods=] do not have such access since they are invoked [=in parallel=] (by algorithms specified in [[!CREDENTIAL-MANAGEMENT-1]]).
@@ -906,7 +907,7 @@ applicable. The below subsections comprise the current Secure Payment
 Confirmation-specific privacy considerations, where this specification diverges
 from WebAuthn.
 
-## Enrollment in a Cross-Origin iframe ## {#sctn-security-cross-origin-enrollment}
+## Registration in a Cross-Origin iframe ## {#sctn-security-cross-origin-registration}
 
 Unlike WebAuthn, this specification allows the creation of credentials in a
 cross-origin iframe (as long as the appropriate


### PR DESCRIPTION
In alignment with Web Authentication, use "registration" instead of "enrollment":
https://w3c.github.io/webauthn/#sctn-usecase-registration

This is an editorial change with no impact on the API / deployed code.


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/secure-payment-confirmation/pull/115.html" title="Last updated on Aug 23, 2021, 6:08 PM UTC (52017db)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/secure-payment-confirmation/115/5906d61...52017db.html" title="Last updated on Aug 23, 2021, 6:08 PM UTC (52017db)">Diff</a>