### PR TITLE
Preparing for FPWD (and then auto-publishing)

### DIFF
--- a/spec.bs
+++ b/spec.bs
@@ -6,17 +6,18 @@ TR: https://www.w3.org/TR/secure-payment-confirmation/
 ED: https://w3c.github.io/secure-payment-confirmation/
 Prepare for TR: true
 Inline Github Issues: true
-Group: web-payments
+Group: payments
 Status: w3c/ED
 Level: 1
 URL: https://w3c.github.io/secure-payment-confirmation
-Editor: Rouslan Solomakhin, Google https://www.google.com/, rouslan@chromium.org
-Editor: Stephen McGruer, Google https://www.google.com/, smcgruer@chromium.org
+Editor: Rouslan Solomakhin, w3cid 83784, Google https://www.google.com/, rouslan@chromium.org
+Editor: Stephen McGruer, w3cid 96463, Google https://www.google.com/, smcgruer@chromium.org
 Abstract: Secure Payment Confirmation (SPC) is a Web API to support streamlined
   authentication during a payment transaction. It is designed to scale authentication
   across merchants, to be used within a wide range of authentication protocols, and
   to produce cryptographic evidence that the user has confirmed transaction details.
 Complain About: missing-example-ids true
+Local Boilerplate: status yes
 Markup Shorthands: markdown yes
 </pre>
 

--- a/status-ED.include
+++ b/status-ED.include
@@ -1,0 +1,35 @@
+<p><em>This section describes the status of this document at the time of its publication. Other documents may supersede this document. A list of current W3C publications and the latest revision of this technical report can be found in the <a href="https://www.w3.org/TR/">W3C technical reports index</a> at https://www.w3.org/TR/.</em></p>
+  <p>
+    This document was published by the <a href="https://www.w3.org/Payments/WG/">Web Payments Working Group</a>
+    as an Editors' Draft. This document is intended to become a W3C Recommendation.
+
+    Feedback and comments on this specification are welcome. Please use
+    <a href="https://github.com/w3c/secure-payment-confirmation/issues">Github issues</a>.
+    Discussions may also be found in the
+    <a href="http://lists.w3.org/Archives/Public/public-payments-wg/">public-payments-wg@w3.org archives</a>.
+  </p>
+  <p>
+    Publication as an Editors' Draft does not imply endorsement by the
+    <abbr title="World Wide Web Consortium">W3C</abbr> Membership. This is a draft document and may
+    be updated, replaced or obsoleted by other documents at any time. It is inappropriate to cite
+    this document as other than work in progress.
+  </p>
+  <p>
+    This document was produced by a group operating under the
+    <a href="https://www.w3.org/Consortium/Patent-Policy-20170801/">
+    <abbr title="World Wide Web Consortium">W3C</abbr> Patent Policy</a>.
+    <abbr title="World Wide Web Consortium">W3C</abbr> maintains a
+    <a href="https://www.w3.org/groups/wg/payments/ipr" rel="disclosure">public list of any
+    patent disclosures</a> made in connection with the deliverables of the group; that page also
+    includes instructions for disclosing a patent. An individual who has actual knowledge of a
+    patent which the individual believes contains
+    <a href="https://www.w3.org/Consortium/Patent-Policy-20170801/#def-essential">Essential
+    Claim(s)</a> must disclose the information in accordance with
+    <a href="https://www.w3.org/Consortium/Patent-Policy-20170801/#sec-Disclosure">section 6 of the
+    <abbr title="World Wide Web Consortium">W3C</abbr> Patent Policy</a>.
+  </p>
+  <p>
+    This document is governed by the <a id="w3c_process_revision" href="https://www.w3.org/2020/Process-20200915/">15 September 2020 W3C Process Document</a>.
+  </p>
+
+  <p>[STATUSTEXT]

--- a/status-FPWD.include
+++ b/status-FPWD.include
@@ -1,0 +1,35 @@
+<p><em>This section describes the status of this document at the time of its publication. Other documents may supersede this document. A list of current W3C publications and the latest revision of this technical report can be found in the <a href="https://www.w3.org/TR/">W3C technical reports index</a> at https://www.w3.org/TR/.</em></p>
+  <p>
+    This document was published by the <a href="https://www.w3.org/Payments/WG/">Web Payments Working Group</a>
+    as a First Public Working Draft. This document is intended to become a W3C Recommendation.
+
+    Feedback and comments on this specification are welcome. Please use
+    <a href="https://github.com/w3c/secure-payment-confirmation/issues">Github issues</a>.
+    Discussions may also be found in the
+    <a href="http://lists.w3.org/Archives/Public/public-payments-wg/">public-payments-wg@w3.org archives</a>.
+  </p>
+  <p>
+    Publication as a First Public Working Draft does not imply endorsement by the
+    <abbr title="World Wide Web Consortium">W3C</abbr> Membership. This is a draft document and may
+    be updated, replaced or obsoleted by other documents at any time. It is inappropriate to cite
+    this document as other than work in progress.
+  </p>
+  <p>
+    This document was produced by a group operating under the
+    <a href="https://www.w3.org/Consortium/Patent-Policy-20170801/">
+    <abbr title="World Wide Web Consortium">W3C</abbr> Patent Policy</a>.
+    <abbr title="World Wide Web Consortium">W3C</abbr> maintains a
+    <a href="https://www.w3.org/groups/wg/payments/ipr" rel="disclosure">public list of any
+    patent disclosures</a> made in connection with the deliverables of the group; that page also
+    includes instructions for disclosing a patent. An individual who has actual knowledge of a
+    patent which the individual believes contains
+    <a href="https://www.w3.org/Consortium/Patent-Policy-20170801/#def-essential">Essential
+    Claim(s)</a> must disclose the information in accordance with
+    <a href="https://www.w3.org/Consortium/Patent-Policy-20170801/#sec-Disclosure">section 6 of the
+    <abbr title="World Wide Web Consortium">W3C</abbr> Patent Policy</a>.
+  </p>
+  <p>
+    This document is governed by the <a id="w3c_process_revision" href="https://www.w3.org/2020/Process-20200915/">15 September 2020 W3C Process Document</a>.
+  </p>
+
+  <p>[STATUSTEXT]

--- a/status-WD.include
+++ b/status-WD.include
@@ -1,0 +1,35 @@
+<p><em>This section describes the status of this document at the time of its publication. Other documents may supersede this document. A list of current W3C publications and the latest revision of this technical report can be found in the <a href="https://www.w3.org/TR/">W3C technical reports index</a> at https://www.w3.org/TR/.</em></p>
+  <p>
+    This document was published by the <a href="https://www.w3.org/Payments/WG/">Web Payments Working Group</a>
+    as a Working Draft. This document is intended to become a W3C Recommendation.
+
+    Feedback and comments on this specification are welcome. Please use
+    <a href="https://github.com/w3c/secure-payment-confirmation/issues">Github issues</a>.
+    Discussions may also be found in the
+    <a href="http://lists.w3.org/Archives/Public/public-payments-wg/">public-payments-wg@w3.org archives</a>.
+  </p>
+  <p>
+    Publication as a Working Draft does not imply endorsement by the
+    <abbr title="World Wide Web Consortium">W3C</abbr> Membership. This is a draft document and may
+    be updated, replaced or obsoleted by other documents at any time. It is inappropriate to cite
+    this document as other than work in progress.
+  </p>
+  <p>
+    This document was produced by a group operating under the
+    <a href="https://www.w3.org/Consortium/Patent-Policy-20170801/">
+    <abbr title="World Wide Web Consortium">W3C</abbr> Patent Policy</a>.
+    <abbr title="World Wide Web Consortium">W3C</abbr> maintains a
+    <a href="https://www.w3.org/groups/wg/payments/ipr" rel="disclosure">public list of any
+    patent disclosures</a> made in connection with the deliverables of the group; that page also
+    includes instructions for disclosing a patent. An individual who has actual knowledge of a
+    patent which the individual believes contains
+    <a href="https://www.w3.org/Consortium/Patent-Policy-20170801/#def-essential">Essential
+    Claim(s)</a> must disclose the information in accordance with
+    <a href="https://www.w3.org/Consortium/Patent-Policy-20170801/#sec-Disclosure">section 6 of the
+    <abbr title="World Wide Web Consortium">W3C</abbr> Patent Policy</a>.
+  </p>
+  <p>
+    This document is governed by the <a id="w3c_process_revision" href="https://www.w3.org/2020/Process-20200915/">15 September 2020 W3C Process Document</a>.
+  </p>
+
+  <p>[STATUSTEXT]


### PR DESCRIPTION
* Updates some metadata in spec.bs for W3C pubrules (but leaves Status as ED)
* Adds some boilerplate for Status Section of upcoming FPWD, subsequent EDs, and subsequent WDs


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/secure-payment-confirmation/pull/118.html" title="Last updated on Aug 24, 2021, 2:07 PM UTC (0ba14d5)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/secure-payment-confirmation/118/7abc234...0ba14d5.html" title="Last updated on Aug 24, 2021, 2:07 PM UTC (0ba14d5)">Diff</a>