### PR TITLE
Speak to current implementation limitation regarding userVerification

### DIFF
--- a/spec.bs
+++ b/spec.bs
@@ -551,6 +551,8 @@ The [=steps to respond to a payment request=] for this payment method, for a giv
     "{{PublicKeyCredentialRequestOptions/userVerification}}" → {{UserVerificationRequirement/required}},
     "{{PublicKeyCredentialRequestOptions/extensions}}" → |extensions|]».
 
+    Note: This algorithm hard-codes "required" as the value for {{PublicKeyCredentialRequestOptions/userVerification}} because that is what Chrome's initial implementation supports. The current limitation may change. The Working Group invites implementers to share use cases that would benefit from support for other values ("preferred", "discouraged").
+
 1. For each |id| in `data.credentialIds`:
 
     1. Let |descriptor| be a new {{PublicKeyCredentialDescriptor}} dictionary, initialized as


### PR DESCRIPTION
Addresses issue #119


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/secure-payment-confirmation/pull/120.html" title="Last updated on Aug 25, 2021, 10:13 PM UTC (320ac6c)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/secure-payment-confirmation/120/24997c1...320ac6c.html" title="Last updated on Aug 25, 2021, 10:13 PM UTC (320ac6c)">Diff</a>