### PR TITLE
[Spec] Correctly specify authenticatorSelection requirements

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -13,6 +13,7 @@ jobs:
       - uses: w3c/spec-prod@v2
         with:
           GH_PAGES_BRANCH: gh-pages
+          BUILD_FAIL_ON: warning
           TOOLCHAIN: bikeshed
           SOURCE: spec.bs
           DESTINATION: index.html

--- a/spec.bs
+++ b/spec.bs
@@ -585,7 +585,7 @@ The [=steps to respond to a payment request=] for this payment method, for a giv
     : {{PublicKeyCredentialRequestOptions/extensions}}
     :: |extensions|
 
-    Note: This algorithm hard-codes "required" as the value for {{PublicKeyCredentialRequestOptions/userVerification}} and {{PublicKeyCredentialRequestOptions/residentKey}}, as well as "platform" for {{PublicKeyCredentialRequestOptions/authenticatorAttachment}}, because that is what Chrome's initial implementation supports. The current limitations may change. The Working Group invites implementers to share use cases that would benefit from support for other values (e.g., "preferred" or "discouraged" for userVerification).
+    Note: This algorithm hard-codes "required" as the value for {{PublicKeyCredentialRequestOptions/userVerification}}, because that is what Chrome's initial implementation supports. The current limitations may change. The Working Group invites implementers to share use cases that would benefit from support for other values (e.g., "preferred" or "discouraged").
 
 1. For each |id| in `data.credentialIds`:
 
@@ -690,6 +690,20 @@ directly; for authentication the extension can only be accessed via
          (see [[#sctn-permissions-policy]]). We could additionally require and
          consume a [=transient activation=] here, if we felt the permission policy
          is not sufficient.
+
+    1. After step 3, insert the following step:
+
+        * If any of the following are true:
+
+            * *options*.{{PublicKeyCredentialCreationOptions/authenticatorSelection}}.{{AuthenticatorSelectionCriteria/authenticatorAttachment}} is not "{{AuthenticatorAttachment/platform}}".
+            * *options*.{{PublicKeyCredentialCreationOptions/authenticatorSelection}}.{{AuthenticatorSelectionCriteria/residentKey}} is not "{{ResidentKeyRequirement/required}}".
+            * *options*.{{PublicKeyCredentialCreationOptions/authenticatorSelection}}.{{AuthenticatorSelectionCriteria/userVerification}} is not "{{UserVerificationRequirement/required}}".
+
+            then throw a {{TypeError}}.
+
+            Note: These values are hard-coded as that is what Chrome's initial implementation
+            supports. The current limitations may change. The Working Group invites implementers
+            to share use cases that would benefit from support for other values.
 
 :  Client extension processing ([=authentication extension|authentication=])
 :: When [[webauthn-3#sctn-getAssertion|making an assertion]] with a


### PR DESCRIPTION
These were previously incorrect specified as auth-time requirements, but they
are actually registration time arguments. This was overlooked as the build
action didn't fail on warnings by default. This commit also changes the action
to fail in such cases.

Fixes #129


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/secure-payment-confirmation/pull/132.html" title="Last updated on Oct 1, 2021, 2:56 PM UTC (9c9d0b7)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/secure-payment-confirmation/132/0444d4c...9c9d0b7.html" title="Last updated on Oct 1, 2021, 2:56 PM UTC (9c9d0b7)">Diff</a>