### PR TITLE
Add note on I18N of displayName

### DIFF
--- a/spec.bs
+++ b/spec.bs
@@ -826,6 +826,10 @@ contains the following members:
     :  <dfn>displayName</dfn> member
     :: The name of the payment instrument to be displayed to the user.
 
+         NOTE: For discussion about internationalization of the 
+         {{PaymentCredentialInstrument/displayName}}, see
+         <a href="https://github.com/w3c/secure-payment-confirmation/issues/93">issue 93</a>.
+
     :  <dfn>icon</dfn> member
     :: The URL of the icon of the payment instrument.
 


### PR DESCRIPTION
I propose to add this note with a link to our i18n issue on SPC.


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/secure-payment-confirmation/pull/153.html" title="Last updated on Oct 28, 2021, 1:16 PM UTC (992d380)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/secure-payment-confirmation/153/314b849...992d380.html" title="Last updated on Oct 28, 2021, 1:16 PM UTC (992d380)">Diff</a>