### PR TITLE
Describe protections against "wrong credential" attack

### DIFF
--- a/spec.bs
+++ b/spec.bs
@@ -1095,6 +1095,11 @@ an unauthorized payment using Secure Payment Confirmation credentials
 * If the [=Relying Party=] is expecting a transaction, it will detect an
     unfamiliar `challenge` and reject the assertion.
 
+The same backend protections apply in the scenario where the caller
+intentionally or mistakenly provides the API with instrument
+information and Secure Payment Confirmation credentials not related
+through registration.
+
 ## Merchant-supplied authentication data ## {#sctn-security-merchant-data}
 
 A consequence of this specification's third-party authentication ceremony is

--- a/spec.bs
+++ b/spec.bs
@@ -1095,11 +1095,6 @@ an unauthorized payment using Secure Payment Confirmation credentials
 * If the [=Relying Party=] is expecting a transaction, it will detect an
     unfamiliar `challenge` and reject the assertion.
 
-The same backend protections apply in the scenario where the caller
-intentionally or mistakenly provides the API with instrument
-information and Secure Payment Confirmation credentials not related
-through registration.
-
 ## Merchant-supplied authentication data ## {#sctn-security-merchant-data}
 
 A consequence of this specification's third-party authentication ceremony is
@@ -1114,7 +1109,10 @@ the user:
 This could lead to a spoofing attack, in which a merchant presents incorrect
 data to the user. For example, the merchant could tell the bank (in the
 backend) that it is initiating a purchase of $100, but then pass $1 to the SPC
-API (and thus show the user a $1 transaction to verify).
+API (and thus show the user a $1 transaction to verify). Or the merchant
+could provide the correct transaction details but pass Secure Payment
+Confirmation credentials that don't match what the [=Relying Party=]
+expects.
 
 Secure Payment Confirmation actually makes defeating this kind of attack easier
 than it currently is on the web. In online payments today, the bank has to


### PR DESCRIPTION
New text to cover the attack where a caller intentionally or accidentally calls the API
with an instrument string and completely unrelated (but valid) SPC credentials.


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/secure-payment-confirmation/pull/155.html" title="Last updated on Nov 2, 2021, 9:52 PM UTC (3d4204e)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/secure-payment-confirmation/155/4015745...3d4204e.html" title="Last updated on Nov 2, 2021, 9:52 PM UTC (3d4204e)">Diff</a>