### PR TITLE
Alt for icon

### DIFF
--- a/spec.bs
+++ b/spec.bs
@@ -872,14 +872,8 @@ contains the following members:
          of the {{CollectedClientAdditionalPaymentData}} structure.
 
     :  <dfn>alt</dfn> member
-    :: An optional member that provides a text description of the icon.
-       This member should be used when
-       {{PaymentCredentialInstrument/displayName}} does not already
-       include a sufficient text description of the icon. For example,
-       if {{PaymentCredentialInstrument/displayName}} includes a card
-       payment network name but the icon is that of the issuing bank,
-       use this member to provide a text version of the name of the
-       bank.
+    :: An optional member that provides a text description of the icon. This member should be used when
+       {{PaymentCredentialInstrument/displayName}} does not already include a sufficient text description of the icon. For example, if {{PaymentCredentialInstrument/displayName}} includes a card payment network name but the icon is that of the issuing bank, use this member to provide a text version of the name of the bank.
 </dl>
 
 # Permissions Policy integration # {#sctn-permissions-policy}

--- a/spec.bs
+++ b/spec.bs
@@ -842,7 +842,7 @@ The following data structures are shared between registration and authentication
     dictionary PaymentCredentialInstrument {
         required DOMString displayName;
         required USVString icon;
-                 USVString alt;
+                 DOMString alt;
     };
 </xmp>
 

--- a/spec.bs
+++ b/spec.bs
@@ -556,8 +556,8 @@ authentication:
     {{PaymentCurrencyAmount/currency}} and {{PaymentCurrencyAmount/value}} of the
     transaction.
 * The {{CollectedClientAdditionalPaymentData/instrument}} details, that is the
-    payment instrument {{PaymentCredentialInstrument/displayName}} and
-    {{PaymentCredentialInstrument/icon}}.
+    payment instrument {{PaymentCredentialInstrument/displayName}}, 
+    {{PaymentCredentialInstrument/icon}}, and {{PaymentCredentialInstrument/alt}} (if provided).
 
 If the [=current transaction automation mode=] is not
 "{{TransactionAutomationMode/none}}", the user agent should first verify that
@@ -842,6 +842,7 @@ The following data structures are shared between registration and authentication
     dictionary PaymentCredentialInstrument {
         required DOMString displayName;
         required USVString icon;
+                 USVString alt;
     };
 </xmp>
 
@@ -869,6 +870,16 @@ contains the following members:
          validation because the [=Relying Party=]  has cryptographic evidence of
          what the browser displayed to the user: the icon URL is signed as part
          of the {{CollectedClientAdditionalPaymentData}} structure.
+
+    :  <dfn>alt</dfn> member
+    :: An optional member that provides a text description of the icon.
+       This member should be used when
+       {{PaymentCredentialInstrument/displayName}} does not already
+       include a sufficient text description of the icon. For example,
+       if {{PaymentCredentialInstrument/displayName}} includes a card
+       payment network name but the icon is that of the issuing bank,
+       use this member to provide a text version of the name of the
+       bank.
 </dl>
 
 # Permissions Policy integration # {#sctn-permissions-policy}
@@ -1250,6 +1261,11 @@ As above, a possible solution to this would be to hash the credential ID(s)
 with a random salt, making them non-consistent across calls.
 
 # Accessibility Considerations # {#sctn-accessibility-considerations}
+
+The {{PaymentCredentialInstrument/alt}} member of
+{{CollectedClientAdditionalPaymentData/instrument}} enables developers
+to increase the accessibility of information intended for the user
+(e.g., for use by screen readers).
 
 User Agents implementing this specification should follow both
 [[webauthn-3#sctn-accessiblility-considerations|WebAuthn's Accessibility Considerations]]

--- a/spec.bs
+++ b/spec.bs
@@ -872,8 +872,7 @@ contains the following members:
          of the {{CollectedClientAdditionalPaymentData}} structure.
 
     :  <dfn>alt</dfn> member
-    :: An optional member that provides a text description of the icon. This member should be used when
-       {{PaymentCredentialInstrument/displayName}} does not already include a sufficient text description of the icon. For example, if {{PaymentCredentialInstrument/displayName}} includes a card payment network name but the icon is that of the issuing bank, use this member to provide a text version of the name of the bank.
+    :: An optional member that provides a text description of the icon. This member should be used when {{PaymentCredentialInstrument/displayName}} does not already include a sufficient text description of the icon. For example, if {{PaymentCredentialInstrument/displayName}} includes a card payment network name but the icon is that of the issuing bank, use this member to provide a text version of the name of the bank.
 </dl>
 
 # Permissions Policy integration # {#sctn-permissions-policy}

--- a/spec.bs
+++ b/spec.bs
@@ -1262,10 +1262,10 @@ with a random salt, making them non-consistent across calls.
 
 # Accessibility Considerations # {#sctn-accessibility-considerations}
 
-The {{PaymentCredentialInstrument/alt}} member of
-{{CollectedClientAdditionalPaymentData/instrument}} enables developers
-to increase the accessibility of information intended for the user
-(e.g., for use by screen readers).
+When {{PaymentCredentialInstrument/displayName}} is not sufficient to
+describe an {{PaymentCredentialInstrument/icon}},
+{{PaymentCredentialInstrument/alt}} is designed to increase the
+accessibility of the icon (e.g., for use by screen readers).
 
 User Agents implementing this specification should follow both
 [[webauthn-3#sctn-accessiblility-considerations|WebAuthn's Accessibility Considerations]]


### PR DESCRIPTION
To improve accessibility and address #127, a proposal add an optional "alt" to instrument details when displayName is not sufficient to describe the icon.

P.S. I named the pull request 217 instead of 127. Sorry!


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/secure-payment-confirmation/pull/156.html" title="Last updated on Nov 8, 2021, 1:59 PM UTC (851cc4c)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/secure-payment-confirmation/156/cd8781c...851cc4c.html" title="Last updated on Nov 8, 2021, 1:59 PM UTC (851cc4c)">Diff</a>