### PR TITLE
Enhanced note about role of user data in example

### DIFF
--- a/spec.bs
+++ b/spec.bs
@@ -255,7 +255,11 @@ const publicKey = {
 
   // User:
   user: {
-    // An id that the bank server can use to identify this user in future interactions.
+    // Part of WebAuthn. This information is not required by SPC
+    // but may be used by the bank server to identify this user in
+    // future transactions. Inconsistent values for the same user
+    // can result in the creation of multiple credentials for the user
+    // and thus potential UX friction due to credential selection.
     id: Uint8Array.from(window.atob("MIIBkzCCATigAwIBAjCCAZMwggE4oAMCAQIwggGTMII="), c=>c.charCodeAt(0)),
     name: "jane.doe@example.com",
     displayName: "Jane Doe",


### PR DESCRIPTION
* Point out that "user" info is not part of SPC, and
* Heads up on consistent usage to avoid credential
  selection as discussed in the SPC TF:
  https://www.w3.org/2021/11/08-wpwg-spc-minutes#t01


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/secure-payment-confirmation/pull/158.html" title="Last updated on Nov 10, 2021, 5:19 PM UTC (2232725)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/secure-payment-confirmation/158/cd8781c...2232725.html" title="Last updated on Nov 10, 2021, 5:19 PM UTC (2232725)">Diff</a>