### PR TITLE
Implementation note related to N matching credentials

### DIFF
--- a/spec.bs
+++ b/spec.bs
@@ -637,7 +637,9 @@ The [=steps to respond to a payment request=] for this payment method, for a giv
     [=Request a Credential=], passing «["{{CredentialRequestOptions/publicKey}}"
     → |publicKeyOpts|]».
 
-    Note: Chrome's initial implementation does not run the algorithm to [=Request a Credential=]. Instead, it chooses the first matching credential in the list.
+    Note: Chrome's initial implementation does not pass the full `credentialIds`
+          list to [=Request a Credential=]. Instead, it chooses one credential
+	  in the list that matches the current device and passes only that in.
 
     Note: This triggers [[webauthn-3]]'s [[webauthn-3#sctn-getAssertion|Get]] behavior
 

--- a/spec.bs
+++ b/spec.bs
@@ -637,9 +637,7 @@ The [=steps to respond to a payment request=] for this payment method, for a giv
     [=Request a Credential=], passing «["{{CredentialRequestOptions/publicKey}}"
     → |publicKeyOpts|]».
 
-    Note: Chrome's initial implementation does not pass the full `credentialIds`
-          list to [=Request a Credential=]. Instead, it chooses one credential
-          in the list that matches the current device and passes only that in.
+    Note: Chrome's initial implementation does not pass the full `credentialIds` list to [=Request a Credential=]. Instead, it chooses one credential in the list that matches the current device and passes only that in.
 
     Note: This triggers [[webauthn-3]]'s [[webauthn-3#sctn-getAssertion|Get]] behavior
 

--- a/spec.bs
+++ b/spec.bs
@@ -637,7 +637,7 @@ The [=steps to respond to a payment request=] for this payment method, for a giv
     [=Request a Credential=], passing «["{{CredentialRequestOptions/publicKey}}"
     → |publicKeyOpts|]».
 
-    Note: Chrome's initial implementation does not pass the full `credentialIds` list to [=Request a Credential=]. Instead, it chooses one credential in the list that matches the current device and passes only that in.
+    Note: Chrome's initial implementation does not pass the full `data.credentialIds` list to [=Request a Credential=]. Instead, it chooses one credential in the list that matches the current device and passes only that in.
 
     Note: This triggers [[webauthn-3]]'s [[webauthn-3#sctn-getAssertion|Get]] behavior
 

--- a/spec.bs
+++ b/spec.bs
@@ -639,7 +639,7 @@ The [=steps to respond to a payment request=] for this payment method, for a giv
 
     Note: Chrome's initial implementation does not pass the full `credentialIds`
           list to [=Request a Credential=]. Instead, it chooses one credential
-	  in the list that matches the current device and passes only that in.
+          in the list that matches the current device and passes only that in.
 
     Note: This triggers [[webauthn-3]]'s [[webauthn-3#sctn-getAssertion|Get]] behavior
 

--- a/spec.bs
+++ b/spec.bs
@@ -637,6 +637,8 @@ The [=steps to respond to a payment request=] for this payment method, for a giv
     [=Request a Credential=], passing «["{{CredentialRequestOptions/publicKey}}"
     → |publicKeyOpts|]».
 
+    Note: Chrome's initial implementation does not run the algorithm to [=Request a Credential=]. Instead, it chooses the first matching credential in the list.
+
     Note: This triggers [[webauthn-3]]'s [[webauthn-3#sctn-getAssertion|Get]] behavior
 
 1. Return |outputCredential|.


### PR DESCRIPTION
Partially addresses #69.

It seems that issue 69 is addressed by the specification, which says to follow a credential management API algorithm. However, since that is not what the current Chrome implementation does, I propose to add an implementation note.


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/secure-payment-confirmation/pull/159.html" title="Last updated on Nov 12, 2021, 8:29 PM UTC (f1e771c)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/secure-payment-confirmation/159/14e5471...f1e771c.html" title="Last updated on Nov 12, 2021, 8:29 PM UTC (f1e771c)">Diff</a>