### PR TITLE
Using displayName for icon accessibility

### DIFF
--- a/spec.bs
+++ b/spec.bs
@@ -874,7 +874,7 @@ contains the following members:
          what the browser displayed to the user: the icon URL is signed as part
          of the {{CollectedClientAdditionalPaymentData}} structure.
 
-	 NOTE: See related [[#sctn-accessibility-considerations|accessibility considerations]].
+         NOTE: See related [[#sctn-accessibility-considerations|accessibility considerations]].
 </dl>
 
 # Permissions Policy integration # {#sctn-permissions-policy}

--- a/spec.bs
+++ b/spec.bs
@@ -873,6 +873,8 @@ contains the following members:
          validation because the [=Relying Party=]  has cryptographic evidence of
          what the browser displayed to the user: the icon URL is signed as part
          of the {{CollectedClientAdditionalPaymentData}} structure.
+
+	 NOTE: See related [[#sctn-accessiblility-considerations|accessibility consideration]].
 </dl>
 
 # Permissions Policy integration # {#sctn-permissions-policy}
@@ -1254,6 +1256,8 @@ As above, a possible solution to this would be to hash the credential ID(s)
 with a random salt, making them non-consistent across calls.
 
 # Accessibility Considerations # {#sctn-accessibility-considerations}
+
+User agents render the {{PaymentCredentialInstrument/icon}} and {{PaymentCredentialInstrument/displayName}} together. Relying parties ensure the accessibility of the icon presentation by providing sufficient information via the {{PaymentCredentialInstrument/displayName}}. For example, if the icon represents a bank, include the bank name in the {{PaymentCredentialInstrument/displayName}}.
 
 User Agents implementing this specification should follow both
 [[webauthn-3#sctn-accessiblility-considerations|WebAuthn's Accessibility Considerations]]

--- a/spec.bs
+++ b/spec.bs
@@ -874,7 +874,7 @@ contains the following members:
          what the browser displayed to the user: the icon URL is signed as part
          of the {{CollectedClientAdditionalPaymentData}} structure.
 
-	 NOTE: See related [[#sctn-accessiblility-considerations|accessibility considerations]].
+	 NOTE: See related [[#sctn-accessibility-considerations|accessibility considerations]].
 </dl>
 
 # Permissions Policy integration # {#sctn-permissions-policy}

--- a/spec.bs
+++ b/spec.bs
@@ -874,7 +874,7 @@ contains the following members:
          what the browser displayed to the user: the icon URL is signed as part
          of the {{CollectedClientAdditionalPaymentData}} structure.
 
-	 NOTE: See related [[#sctn-accessiblility-considerations|accessibility consideration]].
+	 NOTE: See related [[#sctn-accessiblility-considerations|accessibility considerations]].
 </dl>
 
 # Permissions Policy integration # {#sctn-permissions-policy}

--- a/spec.bs
+++ b/spec.bs
@@ -1259,7 +1259,7 @@ with a random salt, making them non-consistent across calls.
 
 # Accessibility Considerations # {#sctn-accessibility-considerations}
 
-User agents render the {{PaymentCredentialInstrument/icon}} and {{PaymentCredentialInstrument/displayName}} together. Relying parties ensure the accessibility of the icon presentation by providing sufficient information via the {{PaymentCredentialInstrument/displayName}}. For example, if the icon represents a bank, include the bank name in the {{PaymentCredentialInstrument/displayName}}.
+User agents render the {{PaymentCredentialInstrument/icon}} and {{PaymentCredentialInstrument/displayName}} together. Relying parties ensure the accessibility of the icon presentation by providing sufficient information via the {{PaymentCredentialInstrument/displayName}} (e.g., if the icon represents a bank, by including the bank name in the {{PaymentCredentialInstrument/displayName}}).
 
 User Agents implementing this specification should follow both
 [[webauthn-3#sctn-accessiblility-considerations|WebAuthn's Accessibility Considerations]]


### PR DESCRIPTION
Addresses #127 
Guidance to use the displayName to ensure accessibility.


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/secure-payment-confirmation/pull/162.html" title="Last updated on Nov 12, 2021, 10:32 PM UTC (b6423ce)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/secure-payment-confirmation/162/9ec6e5a...b6423ce.html" title="Last updated on Nov 12, 2021, 10:32 PM UTC (b6423ce)">Diff</a>