### PR TITLE
Add final "/" to "This version" URL

### DIFF
--- a/spec.bs
+++ b/spec.bs
@@ -9,7 +9,7 @@ Inline Github Issues: true
 Group: payments
 Status: w3c/ED
 Level:
-URL: https://w3c.github.io/secure-payment-confirmation
+URL: https://w3c.github.io/secure-payment-confirmation/
 Editor: Rouslan Solomakhin, w3cid 83784, Google https://www.google.com/, rouslan@chromium.org
 Editor: Stephen McGruer, w3cid 96463, Google https://www.google.com/, smcgruer@chromium.org
 Abstract: Secure Payment Confirmation (SPC) is a Web API to support streamlined


### PR DESCRIPTION
URL without the final "/" returns a permanent redirect to the version with a final "/"
(Plus some spec parsing tools get confused by the missing "/")