### PR TITLE
Add option to allow instrument icon download fail

### DIFF
--- a/spec.bs
+++ b/spec.bs
@@ -617,7 +617,7 @@ authentication:
     then the User Agent may show no icon or a generic payment instrument
     icon in its place.
 
-    NOTE: If the icon could not be fetched or decoded, then
+    NOTE: If the specified icon could not be fetched or decoded, then
     {{PaymentCredentialInstrument/iconMustBeShown}} must be `false` here as
     otherwise the [[#sctn-steps-to-check-if-a-payment-can-be-made|the steps
     to check if a payment can be made]] would have failed previously.

--- a/spec.bs
+++ b/spec.bs
@@ -571,7 +571,7 @@ input {{SecurePaymentConfirmationRequest}} |data|, are:
     1. Otherwise, set |data|["{{SecurePaymentConfirmationRequest/instrument}}"]["{{PaymentCredentialInstrument/icon}}"]
         to an empty string.
 
-        Note: This allows the RP to check whether the icon was shown, as the output
+        Note: This allows the RP to check whether the specified icon was shown, as the output
         {{CollectedClientAdditionalPaymentData/instrument}} will have an empty icon
         string.
 

--- a/spec.bs
+++ b/spec.bs
@@ -364,7 +364,6 @@ const request = new PaymentRequest([{
     instrument: {
       displayName: "Fancy Card ****1234",
       icon: "https://fancybank.com/card-art.png",
-      iconMustBeShown: true,
     },
 
     payeeOrigin: "https://merchant.com",
@@ -564,9 +563,17 @@ input {{SecurePaymentConfirmationRequest}} |data|, are:
 
 1. [=fetch an image resource|Fetch the image resource=] for the icon, passing «["{{ImageResource/src}}" →
     |data|["{{SecurePaymentConfirmationRequest/instrument}}"]["{{PaymentCredentialInstrument/icon}}"]]»
-    for *image*. If
-    |data|["{{SecurePaymentConfirmationRequest/instrument}}"]["{{PaymentCredentialInstrument/iconMustBeShown}}"]]
-    is `true` and the fetch fails, then return `false`.
+    for *image*. If this fails:
+
+    1. If |data|["{{SecurePaymentConfirmationRequest/instrument}}"]["{{PaymentCredentialInstrument/iconMustBeShown}}"]
+        is `true`, then return `false`.
+
+    1. Otherwise, set |data|["{{SecurePaymentConfirmationRequest/instrument}}"]["{{PaymentCredentialInstrument/icon}}"]
+        to an empty string.
+
+        Note: This allows the RP to check whether the icon was shown, as the output
+        {{CollectedClientAdditionalPaymentData/instrument}} will have an empty icon
+        string.
 
     Note: The image resource must be fetched whether or not any credential
     matches, to defeat attempts to [[#sctn-privacy-probing-credential-ids|probe
@@ -605,10 +612,13 @@ authentication:
     transaction.
 * The {{CollectedClientAdditionalPaymentData/instrument}} details, that is the
     payment instrument {{PaymentCredentialInstrument/displayName}} and
-    {{PaymentCredentialInstrument/icon}}. If an image resource could not be
-    fetched or decoded from the input {{PaymentCredentialInstrument/icon}}, and
-    {{PaymentCredentialInstrument/iconMustBeShown}} is false, then the User
-    Agent may show no icon or a generic payment instrument icon in its place.
+    {{PaymentCredentialInstrument/icon}}.
+
+    NOTE: If the icon could not be fetched or decoded, then
+    {{PaymentCredentialInstrument/iconMustBeShown}} must be `false` here as
+    otherwise the [[#sctn-steps-to-check-if-a-payment-can-be-made|the steps to check if a payment can be made]]
+    would have failed. In this case, the User Agent may show no icon or a
+    generic payment instrument icon in its place.
 
 If the [=current transaction automation mode=] is not
 "{{TransactionAutomationMode/none}}", the user agent should first verify that
@@ -684,7 +694,7 @@ The [=steps to respond to a payment request=] for this payment method, for a giv
 
     1. [=list/Append=] |descriptor| to |publicKeyOpts|["{{PublicKeyCredentialRequestOptions/allowCredentials}}"].
 
-1. Let |responseDetails| be the result of running the algorithm to
+1. Let |outputCredential| be the result of running the algorithm to
     [=Request a Credential=], passing «["{{CredentialRequestOptions/publicKey}}"
     → |publicKeyOpts|]».
 
@@ -692,15 +702,7 @@ The [=steps to respond to a payment request=] for this payment method, for a giv
 
     Note: This triggers [[webauthn-3]]'s [[webauthn-3#sctn-getAssertion|Get]] behavior
 
-1. Insert a {{boolean}} attribute named `iconShown` to |responseDetails| with
-    the value indicating whether the instrument icon image was successfully
-    fetched and shown in [[#sctn-transaction-confirmation-ux]].
-
-    Note: This means if the value of
-    |data|["{{SecurePaymentConfirmationRequest/instrument}}"]["{{PaymentCredentialInstrument/iconMustBeShown}}"]]
-    is `true`, then a successful response must have `iconShown` equal to `true`.
-
-1. Return |responseDetails|.
+1. Return |outputCredential|.
 
 # WebAuthn Extension - "`payment`" # {#sctn-payment-extension-registration}
 

--- a/spec.bs
+++ b/spec.bs
@@ -612,13 +612,15 @@ authentication:
     transaction.
 * The {{CollectedClientAdditionalPaymentData/instrument}} details, that is the
     payment instrument {{PaymentCredentialInstrument/displayName}} and
-    {{PaymentCredentialInstrument/icon}}.
+    {{PaymentCredentialInstrument/icon}}. If an image resource could not be
+    fetched or decoded from the input {{PaymentCredentialInstrument/icon}},
+    then the User Agent may show no icon or a generic payment instrument
+    icon in its place.
 
     NOTE: If the icon could not be fetched or decoded, then
     {{PaymentCredentialInstrument/iconMustBeShown}} must be `false` here as
-    otherwise the [[#sctn-steps-to-check-if-a-payment-can-be-made|the steps to check if a payment can be made]]
-    would have failed. In this case, the User Agent may show no icon or a
-    generic payment instrument icon in its place.
+    otherwise the [[#sctn-steps-to-check-if-a-payment-can-be-made|the steps
+    to check if a payment can be made]] would have failed previously.
 
 If the [=current transaction automation mode=] is not
 "{{TransactionAutomationMode/none}}", the user agent should first verify that

--- a/spec.bs
+++ b/spec.bs
@@ -364,6 +364,7 @@ const request = new PaymentRequest([{
     instrument: {
       displayName: "Fancy Card ****1234",
       icon: "https://fancybank.com/card-art.png",
+      iconMustBeShown: true,
     },
 
     payeeOrigin: "https://merchant.com",
@@ -563,7 +564,9 @@ input {{SecurePaymentConfirmationRequest}} |data|, are:
 
 1. [=fetch an image resource|Fetch the image resource=] for the icon, passing «["{{ImageResource/src}}" →
     |data|["{{SecurePaymentConfirmationRequest/instrument}}"]["{{PaymentCredentialInstrument/icon}}"]]»
-    for *image*. If this fails, return `false`.
+    for *image*. If
+    |data|["{{SecurePaymentConfirmationRequest/instrument}}"]["{{PaymentCredentialInstrument/iconMustBeShown}}"]]
+    is `true` and the fetch fails, then return `false`.
 
     Note: The image resource must be fetched whether or not any credential
     matches, to defeat attempts to [[#sctn-privacy-probing-credential-ids|probe
@@ -602,7 +605,10 @@ authentication:
     transaction.
 * The {{CollectedClientAdditionalPaymentData/instrument}} details, that is the
     payment instrument {{PaymentCredentialInstrument/displayName}} and
-    {{PaymentCredentialInstrument/icon}}.
+    {{PaymentCredentialInstrument/icon}}. If an image resource could not be
+    fetched or decoded from the input {{PaymentCredentialInstrument/icon}}, and
+    {{PaymentCredentialInstrument/iconMustBeShown}} is false, then the User
+    Agent may show no icon or a generic payment instrument icon in its place.
 
 If the [=current transaction automation mode=] is not
 "{{TransactionAutomationMode/none}}", the user agent should first verify that
@@ -678,7 +684,7 @@ The [=steps to respond to a payment request=] for this payment method, for a giv
 
     1. [=list/Append=] |descriptor| to |publicKeyOpts|["{{PublicKeyCredentialRequestOptions/allowCredentials}}"].
 
-1. Let |outputCredential| be the result of running the algorithm to
+1. Let |responseDetails| be the result of running the algorithm to
     [=Request a Credential=], passing «["{{CredentialRequestOptions/publicKey}}"
     → |publicKeyOpts|]».
 
@@ -686,7 +692,15 @@ The [=steps to respond to a payment request=] for this payment method, for a giv
 
     Note: This triggers [[webauthn-3]]'s [[webauthn-3#sctn-getAssertion|Get]] behavior
 
-1. Return |outputCredential|.
+1. Insert a {{boolean}} attribute named `iconShown` to |responseDetails| with
+    the value indicating whether the instrument icon image was successfully
+    fetched and shown in [[#sctn-transaction-confirmation-ux]].
+
+    Note: This means if the value of
+    |data|["{{SecurePaymentConfirmationRequest/instrument}}"]["{{PaymentCredentialInstrument/iconMustBeShown}}"]]
+    is `true`, then a successful response must have `iconShown` equal to `true`.
+
+1. Return |responseDetails|.
 
 # WebAuthn Extension - "`payment`" # {#sctn-payment-extension-registration}
 
@@ -889,6 +903,7 @@ The following data structures are shared between registration and authentication
     dictionary PaymentCredentialInstrument {
         required DOMString displayName;
         required USVString icon;
+        boolean iconMustBeShown = true;
     };
 </xmp>
 
@@ -918,6 +933,10 @@ contains the following members:
          of the {{CollectedClientAdditionalPaymentData}} structure.
 
          NOTE: See related [[#sctn-accessibility-considerations|accessibility considerations]].
+
+    :  <dfn>iconMustBeShown</dfn> member
+    :: Indicates whether the icon must be successfully fetched and shown for the
+        request to succeed.
 </dl>
 
 # Permissions Policy integration # {#sctn-permissions-policy}

--- a/spec.bs
+++ b/spec.bs
@@ -571,7 +571,7 @@ input {{SecurePaymentConfirmationRequest}} |data|, are:
     1. Otherwise, set |data|["{{SecurePaymentConfirmationRequest/instrument}}"]["{{PaymentCredentialInstrument/icon}}"]
         to an empty string.
 
-        Note: This allows the RP to check whether the specified icon was shown, as the output
+        Note: This lets the RP know that the specified icon was not shown, as the output
         {{CollectedClientAdditionalPaymentData/instrument}} will have an empty icon
         string.
 

--- a/spec.bs
+++ b/spec.bs
@@ -939,7 +939,7 @@ contains the following members:
          NOTE: See related [[#sctn-accessibility-considerations|accessibility considerations]].
 
     :  <dfn>iconMustBeShown</dfn> member
-    :: Indicates whether the icon must be successfully fetched and shown for the
+    :: Indicates whether the specified icon must be successfully fetched and shown for the
         request to succeed.
 </dl>
 


### PR DESCRIPTION
This adds an option to the SecurePaymentConfirmationRequest for the
developer to allow the credential to still be authenticated if the
payment instrument icon fails to download or decode. This is done by
adding an attribute `iconMustBeShown` to the
`PaymentCredentialInstrument`.

The algorithms to check, display, and respond to a request are updated
accordingly.

Issue #125


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/nickburris/secure-payment-confirmation/pull/171.html" title="Last updated on Feb 1, 2022, 3:12 PM UTC (1a94537)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/secure-payment-confirmation/171/edcdaa5...nickburris:1a94537.html" title="Last updated on Feb 1, 2022, 3:12 PM UTC (1a94537)">Diff</a>