### PR TITLE
[Spec] Remove example from 11.2

### DIFF
--- a/spec.bs
+++ b/spec.bs
@@ -1284,11 +1284,9 @@ to distinguish between these cases:
 * A credential is not available.
 * A credential is available, but the user does not consent to use it.
 
-For example, consider an implementation that does not download the payment
-instrument icon unless a credential matches. A caller could then provide an
-unique URL that they control for the payment instrument icon. If the URL is
-accessed then the caller can conclude that at least one of the passed
-credentials is available to the user.
+If the above cases are distinguishable, information is leaked by which a
+malicious [=Relying Party=] could identify the user by probing for which
+[=public key credential|credentials=] are available.
 
 ## Joining different payment instruments ## {#sctn-privacy-joining-payment-instruments}
 


### PR DESCRIPTION
The example was misleading, as it is already explicitly disallowed by the spec
(see 4.1.4, step 8). Removing it hopefully makes it clear that 11.2 is about a
general class of risk that SPC (and WebAuthn) has as a technology, not a
specific attack with a specific mitigation.

See #142


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/secure-payment-confirmation/pull/176.html" title="Last updated on Mar 2, 2022, 3:49 PM UTC (f7601f8)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/secure-payment-confirmation/176/97f5847...f7601f8.html" title="Last updated on Mar 2, 2022, 3:49 PM UTC (f7601f8)">Diff</a>