### PR TITLE
Add payeeName input to spec

### DIFF
--- a/spec.bs
+++ b/spec.bs
@@ -372,6 +372,7 @@ const request = new PaymentRequest([{
       icon: "https://fancybank.com/card-art.png",
     },
 
+    payeeName: "Merchant Shop",
     payeeOrigin: "https://merchant.com",
 
     timeout: 360000,  // 6 minutes
@@ -512,7 +513,8 @@ Add the following to the [=registry of standardized payment methods=] in
         required FrozenArray<BufferSource> credentialIds;
         required PaymentCredentialInstrument instrument;
         unsigned long timeout;
-        required USVString payeeOrigin;
+        DOMString payeeName;
+        USVString payeeOrigin;
         AuthenticationExtensionsClientInputs extensions;
     };
 </xmp>
@@ -540,9 +542,18 @@ members:
     :: The number of milliseconds before the request to sign the transaction
         details times out. At most 1 hour.
 
+    :  <dfn>payeeName</dfn> member
+    :: The display name of the payee that this SPC call is for (e.g., the
+        merchant). Optional, may be provided alongside or instead of
+        {{SecurePaymentConfirmationRequest/payeeOrigin}}.
+
     :  <dfn>payeeOrigin</dfn> member
     :: The [=/origin=] of the payee that this SPC call is for (e.g., the
-        merchant).
+        merchant). Optional, may be provided alongside or instead of
+        {{SecurePaymentConfirmationRequest/payeeName}}.
+
+    Note: Either one or both of {{SecurePaymentConfirmationRequest/payeeName}}
+    or {{SecurePaymentConfirmationRequest/payeeOrigin}} must be provided.
 
     :  <dfn>extensions</dfn> member
     :: Any [=WebAuthn extensions=] that should be used for the passed
@@ -562,15 +573,22 @@ input {{SecurePaymentConfirmationRequest}} |data|, are:
 1. If |data|["{{SecurePaymentConfirmationRequest/rpId}}"] is not a
     [=valid domain=], return `false`.
 
-1. Let |parsedURL| be the result of running the [=URL parser=] on
-    |data|["{{SecurePaymentConfirmationRequest/payeeOrigin}}"].
+1. If both |data|["{{SecurePaymentConfirmationRequest/payeeName}}"] and
+    |data|["{{SecurePaymentConfirmationRequest/payeeOrigin}}"] are omitted or
+    empty, return `false`.
 
-1. If |parsedURL| is failure, then return `false`.
+1. If |data|["{{SecurePaymentConfirmationRequest/payeeOrigin}}"] is present and
+    non-empty:
 
-1. If |parsedURL|'s [=url/scheme=] is not "`https`", then return `false`.
+    1. Let |parsedURL| be the result of running the [=URL parser=] on
+        |data|["{{SecurePaymentConfirmationRequest/payeeOrigin}}"].
 
-1. Set |data|["{{SecurePaymentConfirmationRequest/payeeOrigin}}"] to the
-    [=serialization of an origin|serialization of=] |parsedURL|'s [=url/origin=].
+    1. If |parsedURL| is failure, then return `false`.
+
+    1. If |parsedURL|'s [=url/scheme=] is not "`https`", then return `false`.
+
+    1. Set |data|["{{SecurePaymentConfirmationRequest/payeeOrigin}}"] to the
+        [=serialization of an origin|serialization of=] |parsedURL|'s [=url/origin=].
 
 1. If |data|["{{SecurePaymentConfirmationRequest/instrument}}"]["{{PaymentCredentialInstrument/displayName}}"]
     is empty, return `false`.
@@ -620,7 +638,8 @@ Payment Confirmation payment handler=] is selected. However, so that a
 is communicated to the user and that the user's consent is collected for the
 authentication:
 
-* The {{CollectedClientAdditionalPaymentData/payeeOrigin}}.
+* The {{CollectedClientAdditionalPaymentData/payeeName}} if it is present.
+* The {{CollectedClientAdditionalPaymentData/payeeOrigin}} if it is present.
 * The {{CollectedClientAdditionalPaymentData/total}}, that is the
     {{PaymentCurrencyAmount/currency}} and {{PaymentCurrencyAmount/value}} of the
     transaction.
@@ -667,8 +686,10 @@ The [=steps to respond to a payment request=] for this payment method, for a giv
     :: |data|["{{SecurePaymentConfirmationRequest/rpId}}"]
     : {{AuthenticationExtensionsPaymentInputs/topOrigin}}
     :: |topOrigin|
+    : {{AuthenticationExtensionsPaymentInputs/payeeName}}
+    :: |data|["{{SecurePaymentConfirmationRequest/payeeName}}"] if it is present, otherwise omitted.
     : {{AuthenticationExtensionsPaymentInputs/payeeOrigin}}
-    :: |data|["{{SecurePaymentConfirmationRequest/payeeOrigin}}"]
+    :: |data|["{{SecurePaymentConfirmationRequest/payeeOrigin}}"] if it is present, otherwise omitted.
     : {{AuthenticationExtensionsPaymentInputs/total}}
     :: |request|.[=payment request details|[[details]]=]["{{PaymentDetailsInit/total}}"]
     : {{AuthenticationExtensionsPaymentInputs/instrument}}
@@ -756,6 +777,7 @@ directly; for authentication the extension can only be accessed via
       // Only used for authentication.
       USVString rp;
       USVString topOrigin;
+      DOMString payeeName;
       USVString payeeOrigin;
       PaymentCurrencyAmount total;
       PaymentCredentialInstrument instrument;
@@ -774,8 +796,11 @@ directly; for authentication the extension can only be accessed via
       :  <dfn>topOrigin</dfn> member
       :: The origin of the top-level frame. Only valid at authentication time.
 
+      :  <dfn>payeeName</dfn> member
+      :: The payee name, if present, that was displayed to the user. Only valid at authentication time.
+
       :  <dfn>payeeOrigin</dfn> member
-      :: The payee origin that was displayed to the user. Only valid at authentication time.
+      :: The payee origin, if present, that was displayed to the user. Only valid at authentication time.
 
       :  <dfn>total</dfn> member
       :: The transaction amount that was displayed to the user. Only valid at authentication time.
@@ -844,8 +869,10 @@ directly; for authentication the extension can only be accessed via
                 :: |extension_inputs|["{{AuthenticationExtensionsPaymentInputs/rp}}"]
                 : {{CollectedClientAdditionalPaymentData/topOrigin}}
                 :: |extension_inputs|["{{AuthenticationExtensionsPaymentInputs/topOrigin}}"]
+                : {{CollectedClientAdditionalPaymentData/payeeName}}
+                :: |extension_inputs|["{{AuthenticationExtensionsPaymentInputs/payeeName}}"] if it is present, otherwise omitted.
                 : {{CollectedClientAdditionalPaymentData/payeeOrigin}}
-                :: |extension_inputs|["{{AuthenticationExtensionsPaymentInputs/payeeOrigin}}"]
+                :: |extension_inputs|["{{AuthenticationExtensionsPaymentInputs/payeeOrigin}}"] if it is present, otherwise omitted.
                 : {{CollectedClientAdditionalPaymentData/total}}
                 :: |extension_inputs|["{{AuthenticationExtensionsPaymentInputs/total}}"]
                 : {{CollectedClientAdditionalPaymentData/instrument}}
@@ -881,7 +908,8 @@ The {{CollectedClientPaymentData}} dictionary inherits from
     dictionary CollectedClientAdditionalPaymentData {
         required USVString rp;
         required USVString topOrigin;
-        required USVString payeeOrigin;
+        DOMString payeeName;
+        USVString payeeOrigin;
         required PaymentCurrencyAmount total;
         required PaymentCredentialInstrument instrument;
     };
@@ -897,8 +925,11 @@ fields:
     :  <dfn>topOrigin</dfn> member
     :: The origin of the top level context that requested to sign the transaction details.
 
+    :  <dfn>payeeName</dfn> member
+    :: The name of the payee, if present, that was displayed to the user.
+
     :  <dfn>payeeOrigin</dfn> member
-    :: The origin of the payee that was displayed to the user.
+    :: The origin of the payee, if present, that was displayed to the user.
 
     :  <dfn>total</dfn> member
     :: The {{PaymentCurrencyAmount}} of the [[payment-request]] `total` field.
@@ -1013,6 +1044,9 @@ Confirmation, the [=Relying Party=] MUST proceed as follows:
 
         * Verify that the value of |C|["{{CollectedClientPaymentData/payment}}"]["{{CollectedClientAdditionalPaymentData/topOrigin}}"]
             matches the top-level origin that the [=Relying Party=] expects.
+
+        * Verify that the value of |C|["{{CollectedClientPaymentData/payment}}"]["{{CollectedClientAdditionalPaymentData/payeeName}}"]
+            matches the name of the payee that should have been displayed to the user.
 
         * Verify that the value of |C|["{{CollectedClientPaymentData/payment}}"]["{{CollectedClientAdditionalPaymentData/payeeOrigin}}"]
             matches the origin of the payee that should have been displayed to the user.

--- a/spec.bs
+++ b/spec.bs
@@ -1233,7 +1233,7 @@ transaction details that are shown to the user:
 
 * Transaction amount and currency
 * Payment instrument name and icon
-* Payee origin
+* Payee name and origin
 
 This could lead to a spoofing attack, in which a merchant presents incorrect
 data to the user. For example, the merchant could tell the bank (in the

--- a/spec.bs
+++ b/spec.bs
@@ -793,22 +793,22 @@ directly; for authentication the extension can only be accessed via
         <div class="note">**TODO**: Find a better way to do this. Needed currently because other members are auth-time only.</div>
 
       :  <dfn>rp</dfn> member
-      :: The [=Relying Party=] id of the credential(s) being used. Only valid at authentication time.
+      :: The [=Relying Party=] id of the credential(s) being used. Only used at authentication time; not registration.
 
       :  <dfn>topOrigin</dfn> member
-      :: The origin of the top-level frame. Only valid at authentication time.
+      :: The origin of the top-level frame. Only used at authentication time; not registration.
 
       :  <dfn>payeeName</dfn> member
-      :: The payee name, if present, that was displayed to the user. Only valid at authentication time.
+      :: The payee name, if present, that was displayed to the user. Only used at authentication time; not registration.
 
       :  <dfn>payeeOrigin</dfn> member
-      :: The payee origin, if present, that was displayed to the user. Only valid at authentication time.
+      :: The payee origin, if present, that was displayed to the user. Only used at authentication time; not registration.
 
       :  <dfn>total</dfn> member
-      :: The transaction amount that was displayed to the user. Only valid at authentication time.
+      :: The transaction amount that was displayed to the user. Only used at authentication time; not registration.
 
       :  <dfn>instrument</dfn> member
-      :: The instrument details that were displayed to the user. Only valid at authentication time.
+      :: The instrument details that were displayed to the user. Only used at authentication time; not registration.
 
     </dl>
 

--- a/spec.bs
+++ b/spec.bs
@@ -552,9 +552,6 @@ members:
         merchant). Optional, may be provided alongside or instead of
         {{SecurePaymentConfirmationRequest/payeeName}}.
 
-    Note: Either one or both of {{SecurePaymentConfirmationRequest/payeeName}}
-    or {{SecurePaymentConfirmationRequest/payeeOrigin}} must be provided.
-
     :  <dfn>extensions</dfn> member
     :: Any [=WebAuthn extensions=] that should be used for the passed
         credential(s). The caller does not need to specify the
@@ -687,9 +684,11 @@ The [=steps to respond to a payment request=] for this payment method, for a giv
     : {{AuthenticationExtensionsPaymentInputs/topOrigin}}
     :: |topOrigin|
     : {{AuthenticationExtensionsPaymentInputs/payeeName}}
-    :: |data|["{{SecurePaymentConfirmationRequest/payeeName}}"] if it is present, otherwise omitted.
+    :: |data|["{{SecurePaymentConfirmationRequest/payeeName}}"] if it is
+        present, otherwise omitted.
     : {{AuthenticationExtensionsPaymentInputs/payeeOrigin}}
-    :: |data|["{{SecurePaymentConfirmationRequest/payeeOrigin}}"] if it is present, otherwise omitted.
+    :: |data|["{{SecurePaymentConfirmationRequest/payeeOrigin}}"] if it is
+        present, otherwise omitted.
     : {{AuthenticationExtensionsPaymentInputs/total}}
     :: |request|.[=payment request details|[[details]]=]["{{PaymentDetailsInit/total}}"]
     : {{AuthenticationExtensionsPaymentInputs/instrument}}
@@ -870,9 +869,11 @@ directly; for authentication the extension can only be accessed via
                 : {{CollectedClientAdditionalPaymentData/topOrigin}}
                 :: |extension_inputs|["{{AuthenticationExtensionsPaymentInputs/topOrigin}}"]
                 : {{CollectedClientAdditionalPaymentData/payeeName}}
-                :: |extension_inputs|["{{AuthenticationExtensionsPaymentInputs/payeeName}}"] if it is present, otherwise omitted.
+                :: |extension_inputs|["{{AuthenticationExtensionsPaymentInputs/payeeName}}"]
+                    if it is present, otherwise omitted.
                 : {{CollectedClientAdditionalPaymentData/payeeOrigin}}
-                :: |extension_inputs|["{{AuthenticationExtensionsPaymentInputs/payeeOrigin}}"] if it is present, otherwise omitted.
+                :: |extension_inputs|["{{AuthenticationExtensionsPaymentInputs/payeeOrigin}}"]
+                    if it is present, otherwise omitted.
                 : {{CollectedClientAdditionalPaymentData/total}}
                 :: |extension_inputs|["{{AuthenticationExtensionsPaymentInputs/total}}"]
                 : {{CollectedClientAdditionalPaymentData/instrument}}

--- a/spec.bs
+++ b/spec.bs
@@ -571,11 +571,14 @@ input {{SecurePaymentConfirmationRequest}} |data|, are:
     [=valid domain=], return `false`.
 
 1. If both |data|["{{SecurePaymentConfirmationRequest/payeeName}}"] and
-    |data|["{{SecurePaymentConfirmationRequest/payeeOrigin}}"] are omitted or
+    |data|["{{SecurePaymentConfirmationRequest/payeeOrigin}}"] are omitted,
+    return `false`.
+
+1. If either of |data|["{{SecurePaymentConfirmationRequest/payeeName}}"] or
+    |data|["{{SecurePaymentConfirmationRequest/payeeOrigin}}"] is present and
     empty, return `false`.
 
-1. If |data|["{{SecurePaymentConfirmationRequest/payeeOrigin}}"] is present and
-    non-empty:
+1. If |data|["{{SecurePaymentConfirmationRequest/payeeOrigin}}"] is present:
 
     1. Let |parsedURL| be the result of running the [=URL parser=] on
         |data|["{{SecurePaymentConfirmationRequest/payeeOrigin}}"].
@@ -1047,10 +1050,10 @@ Confirmation, the [=Relying Party=] MUST proceed as follows:
             matches the top-level origin that the [=Relying Party=] expects.
 
         * Verify that the value of |C|["{{CollectedClientPaymentData/payment}}"]["{{CollectedClientAdditionalPaymentData/payeeName}}"]
-            matches the name of the payee that should have been displayed to the user.
+            matches the name of the payee that should have been displayed to the user, if any.
 
         * Verify that the value of |C|["{{CollectedClientPaymentData/payment}}"]["{{CollectedClientAdditionalPaymentData/payeeOrigin}}"]
-            matches the origin of the payee that should have been displayed to the user.
+            matches the origin of the payee that should have been displayed to the user, if any.
 
         * Verify that the value of |C|["{{CollectedClientPaymentData/payment}}"]["{{CollectedClientAdditionalPaymentData/total}}"]
             matches the transaction amount that should have been displayed to the user.


### PR DESCRIPTION
Per the proposal in https://github.com/w3c/secure-payment-confirmation/issues/163, add a payeeName field to the spec.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/nickburris/secure-payment-confirmation/pull/180.html" title="Last updated on Mar 16, 2022, 6:54 PM UTC (132dd9c)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/secure-payment-confirmation/180/72907d8...nickburris:132dd9c.html" title="Last updated on Mar 16, 2022, 6:54 PM UTC (132dd9c)">Diff</a>