### PR TITLE
Add a note in example on meaning of canMakePayment

### DIFF
--- a/spec.bs
+++ b/spec.bs
@@ -386,6 +386,10 @@ const request = new PaymentRequest([{
     },
   });
 
+  /* canMakePayment indicates whether the browser supports SPC. */
+  /* canMakePayment does not indicate whether the user has a credential */
+  /* ready to go on this device. */
+
 try {
   const canMakePayment = await request.canMakePayment();
   if (!canMakePayment) { throw new Error('Cannot make payment'); }


### PR DESCRIPTION
To help mitigate confusion, propose a note on the meaning of canMakePayment in case of SPC


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/secure-payment-confirmation/pull/181.html" title="Last updated on Apr 7, 2022, 6:27 PM UTC (61cf3d1)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/secure-payment-confirmation/181/654c78a...61cf3d1.html" title="Last updated on Apr 7, 2022, 6:27 PM UTC (61cf3d1)">Diff</a>