### PR TITLE
[Spec] Be clearer about authentication ceremony privacy in 4.1.4

### DIFF
--- a/spec.bs
+++ b/spec.bs
@@ -623,11 +623,17 @@ input {{SecurePaymentConfirmationRequest}} |data|, are:
         |id| from |data|["{{SecurePaymentConfirmationRequest/credentialIds}}"].
 
 1. If |data|["{{SecurePaymentConfirmationRequest/credentialIds}}"] is now empty,
-    return `false`. The user agent must take care to maintain
-    [[#sctn-privacy-probing-credential-ids|authentication ceremony privacy]],
-    e.g., by presenting an alternative UI to the user such that the website
-    cannot detect the difference between no-matching credentials and the user
-    declining to authenticate.
+    return `false`. The user agent must maintain
+    [[#sctn-privacy-probing-credential-ids|authentication ceremony privacy]]
+    and not leak this lack of matching credentials to the caller, by:
+
+    1. Not allowing the caller to perform a timing attack on this outcome versus
+        the user declining to authenticate on the
+        [[#sctn-transaction-confirmation-ux|transaction confirmation UX]], e.g.,
+        by presenting an alternative interstitial that the user must interact
+        with.
+    1. Rejecting the {{PaymentRequest/show|show()}} promise with a
+        "{{NotAllowedError}}" {{DOMException}}.
 
 1. Return `true`.
 


### PR DESCRIPTION
Before this PR, the spec was vague about the timing attack and also didn't
specify at all that an implementation must return a NotAllowedError instead of
the normal PaymentRequest NotSupportedError in the case of
no-matching-credentials. Whilst we don't want to enforce that UAs show a dialog
here (they may decide, for example, that a delayed response instead is
sufficiently privacy preserving), this PR does try to make the actual concern
clearer and more normative, and add a normative requirement for the return
value.

Should also improve the situation called out in
https://github.com/w3c/secure-payment-confirmation/issues/142


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/secure-payment-confirmation/pull/182.html" title="Last updated on Apr 27, 2022, 2:01 PM UTC (ffd6cf7)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/secure-payment-confirmation/182/bf15f84...ffd6cf7.html" title="Last updated on Apr 27, 2022, 2:01 PM UTC (ffd6cf7)">Diff</a>