### PR TITLE
[Spec] Add link from 11.2 to 4.1.4

### DIFF
--- a/spec.bs
+++ b/spec.bs
@@ -1348,6 +1348,9 @@ If the above cases are distinguishable, information is leaked by which a
 malicious [=Relying Party=] could identify the user by probing for which
 [=public key credential|credentials=] are available.
 
+Section [[#sctn-steps-to-check-if-a-payment-can-be-made]] gives normative steps
+to mitigate this risk.
+
 ## Joining different payment instruments ## {#sctn-privacy-joining-payment-instruments}
 
 If a [=Relying Party=] uses the same credentials for a given user across


### PR DESCRIPTION
Requested by PING in issue #142


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/secure-payment-confirmation/pull/188.html" title="Last updated on May 4, 2022, 4:42 PM UTC (3fd6578)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/secure-payment-confirmation/188/874d9d6...3fd6578.html" title="Last updated on May 4, 2022, 4:42 PM UTC (3fd6578)">Diff</a>