### PR TITLE
Displayable string language/dir support from document context

### DIFF
--- a/spec.bs
+++ b/spec.bs
@@ -715,7 +715,7 @@ on the value of the [=current transaction automation mode=]:
     :: Act as if the user has seen the transaction details and rejected
         the authentication.
 
-NOTE: The language and direction of the {{CollectedClientAdditionalPaymentData/payeeName} and {{PaymentCredentialInstrument/displayName}} may often be determined from information inherited from the document. For discussion about enhanced support in JavaScript for language and direction of these displayable strings, see<a href="https://github.com/w3c/secure-payment-confirmation/issues/93">issue 93</a>.
+NOTE: The language and direction of the {{CollectedClientAdditionalPaymentData/payeeName} and {{PaymentCredentialInstrument/displayName}} may be determined from information inherited from the document. For discussion about enhanced support in JavaScript for language and direction of these displayable strings, see<a href="https://github.com/w3c/secure-payment-confirmation/issues/93">issue 93</a>.
 
 ### Steps to respond to a payment request ### {#sctn-steps-to-respond-to-a-payment-request}
 

--- a/spec.bs
+++ b/spec.bs
@@ -692,6 +692,8 @@ on the value of the [=current transaction automation mode=]:
     :: Act as if the user has seen the transaction details and rejected
         the authentication.
 
+NOTE: The language and direction of the {{CollectedClientAdditionalPaymentData/payeeName} and {{PaymentCredentialInstrument/displayName}} may often be determined from information inherited from the document. For discussion about enhanced support in JavaScript for language and direction of these displayable strings, see<a href="https://github.com/w3c/secure-payment-confirmation/issues/93">issue 93</a>.
+
 ### Steps to respond to a payment request ### {#sctn-steps-to-respond-to-a-payment-request}
 
 The [=steps to respond to a payment request=] for this payment method, for a given
@@ -1000,10 +1002,6 @@ contains the following members:
 <dl dfn-type="dict-member" dfn-for="PaymentCredentialInstrument">
     :  <dfn>displayName</dfn> member
     :: The name of the payment instrument to be displayed to the user.
-
-         NOTE: For discussion about internationalization of the 
-         {{PaymentCredentialInstrument/displayName}}, see
-         <a href="https://github.com/w3c/secure-payment-confirmation/issues/93">issue 93</a>.
 
     :  <dfn>icon</dfn> member
     :: The URL of the icon of the payment instrument.


### PR DESCRIPTION
Borrow language from the Payment Request API Proposed Recommendation regarding inheritance of language and direction information from the document for use in the browser's native UX.

Intended to address #93


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/secure-payment-confirmation/pull/192.html" title="Last updated on Jun 23, 2022, 3:20 PM UTC (50941a3)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/secure-payment-confirmation/192/12f96d5...50941a3.html" title="Last updated on Jun 23, 2022, 3:20 PM UTC (50941a3)">Diff</a>