### PR TITLE
[Spec] Allow either required or preferred for residentKey

### DIFF
--- a/spec.bs
+++ b/spec.bs
@@ -943,7 +943,7 @@ directly; for authentication the extension can only be accessed via
         * If any of the following are true:
 
             * *options*["{{PublicKeyCredentialCreationOptions/authenticatorSelection}}"]["{{AuthenticatorSelectionCriteria/authenticatorAttachment}}"] is not "{{AuthenticatorAttachment/platform}}".
-            * *options*["{{PublicKeyCredentialCreationOptions/authenticatorSelection}}"]["{{AuthenticatorSelectionCriteria/residentKey}}"] is not "{{ResidentKeyRequirement/required}}".
+            * *options*["{{PublicKeyCredentialCreationOptions/authenticatorSelection}}"]["{{AuthenticatorSelectionCriteria/residentKey}}"] is not "{{ResidentKeyRequirement/required}}" or "{{ResidentKeyRequirement/preferred}}".
             * *options*["{{PublicKeyCredentialCreationOptions/authenticatorSelection}}"]["{{AuthenticatorSelectionCriteria/userVerification}}"] is not "{{UserVerificationRequirement/required}}".
 
             then return a {{TypeError}}.


### PR DESCRIPTION
Android currently does not support discoverable credentials, and so will reject
credential creation if residentKey is set to 'required'. Allowing 'preferred'
as a value allows credential creation on Android.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/secure-payment-confirmation/pull/196.html" title="Last updated on Aug 5, 2022, 8:43 PM UTC (5cbf99f)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/secure-payment-confirmation/196/248a60a...5cbf99f.html" title="Last updated on Aug 5, 2022, 8:43 PM UTC (5cbf99f)">Diff</a>