### PR TITLE
[Spec] Rename rp --> rpId in CollectedClientAdditionalPaymentData

### DIFF
--- a/spec.bs
+++ b/spec.bs
@@ -770,7 +770,7 @@ The [=steps to respond to a payment request=] for this payment method, for a giv
 
     : {{AuthenticationExtensionsPaymentInputs/isPayment}}
     :: The boolean value `true`.
-    : {{AuthenticationExtensionsPaymentInputs/rp}}
+    : {{AuthenticationExtensionsPaymentInputs/rpId}}
     :: |data|["{{SecurePaymentConfirmationRequest/rpId}}"]
     : {{AuthenticationExtensionsPaymentInputs/topOrigin}}
     :: |topOrigin|
@@ -872,7 +872,7 @@ directly; for authentication the extension can only be accessed via
       boolean isPayment;
 
       // Only used for authentication.
-      USVString rp;
+      USVString rpId;
       USVString topOrigin;
       DOMString payeeName;
       USVString payeeOrigin;
@@ -887,7 +887,7 @@ directly; for authentication the extension can only be accessed via
 
         <div class="note">**TODO**: Find a better way to do this. Needed currently because other members are auth-time only.</div>
 
-      :  <dfn>rp</dfn> member
+      :  <dfn>rpId</dfn> member
       :: The [=Relying Party=] id of the credential(s) being used. Only used at authentication time; not registration.
 
       :  <dfn>topOrigin</dfn> member
@@ -989,8 +989,8 @@ directly; for authentication the extension can only be accessed via
             1. {{CollectedClientPaymentData/payment}} set to a new
                 {{CollectedClientAdditionalPaymentData}} whose fields are:
 
-                : {{CollectedClientAdditionalPaymentData/rp}}
-                :: |extension_inputs|["{{AuthenticationExtensionsPaymentInputs/rp}}"]
+                : {{CollectedClientAdditionalPaymentData/rpId}}
+                :: |extension_inputs|["{{AuthenticationExtensionsPaymentInputs/rpId}}"]
                 : {{CollectedClientAdditionalPaymentData/topOrigin}}
                 :: |extension_inputs|["{{AuthenticationExtensionsPaymentInputs/topOrigin}}"]
                 : {{CollectedClientAdditionalPaymentData/payeeName}}
@@ -1036,7 +1036,7 @@ The {{CollectedClientPaymentData}} dictionary inherits from
 
 <xmp class="idl">
     dictionary CollectedClientAdditionalPaymentData {
-        required USVString rp;
+        required USVString rpId;
         required USVString topOrigin;
         DOMString payeeName;
         USVString payeeOrigin;
@@ -1049,8 +1049,12 @@ The {{CollectedClientAdditionalPaymentData}} dictionary contains the following
 fields:
 
 <dl dfn-type="dict-member" dfn-for="CollectedClientAdditionalPaymentData">
-    :  <dfn>rp</dfn> member
+    :  <dfn>rpId</dfn> member
     :: The id of the [=Relying Party=] that created the credential.
+
+           NOTE: For historical reasons, some implementations may additionally
+                 include this parameter with the name `rp`. The values of `rp` and
+                 `rpId` must be the same if both are present.
 
     :  <dfn>topOrigin</dfn> member
     :: The origin of the top level context that requested to sign the transaction details.
@@ -1173,7 +1177,7 @@ Confirmation, the [=Relying Party=] MUST proceed as follows:
 
     1. After step 13, insert the following steps:
 
-        * Verify that the value of |C|["{{CollectedClientPaymentData/payment}}"]["{{CollectedClientAdditionalPaymentData/rp}}"]
+        * Verify that the value of |C|["{{CollectedClientPaymentData/payment}}"]["{{CollectedClientAdditionalPaymentData/rpId}}"]
             matches the [=Relying Party=]'s origin.
 
         * Verify that the value of |C|["{{CollectedClientPaymentData/payment}}"]["{{CollectedClientAdditionalPaymentData/topOrigin}}"]


### PR DESCRIPTION
To align with WebAuthn, we should use the term rpId here. This is a breaking
change, but implementations can mitigate the breakage by continuing to include
the old 'rp' name going forwards.

See https://github.com/w3c/secure-payment-confirmation/issues/191

Test changes: https://github.com/web-platform-tests/wpt/pull/35602
Implementation bugs:
- Chrome: https://crbug.com/1356224
- Safari: N/A
- Firefox: N/A


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/secure-payment-confirmation/pull/198.html" title="Last updated on Aug 24, 2022, 3:49 PM UTC (dd14bfa)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/secure-payment-confirmation/198/7204dc0...dd14bfa.html" title="Last updated on Aug 24, 2022, 3:49 PM UTC (dd14bfa)">Diff</a>