### PR TITLE
[Spec] Dictionary members should be sequence not FrozenArray

### DIFF
--- a/spec.bs
+++ b/spec.bs
@@ -541,7 +541,7 @@ Add the following to the [=registry of standardized payment methods=] in
     dictionary SecurePaymentConfirmationRequest {
         required BufferSource challenge;
         required USVString rpId;
-        required FrozenArray<BufferSource> credentialIds;
+        required sequence<BufferSource> credentialIds;
         required PaymentCredentialInstrument instrument;
         unsigned long timeout;
         DOMString payeeName;


### PR DESCRIPTION
See https://github.com/whatwg/webidl/issues/900


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/secure-payment-confirmation/pull/201.html" title="Last updated on Aug 12, 2022, 2:10 PM UTC (70cdc6a)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/secure-payment-confirmation/201/279b7a3...70cdc6a.html" title="Last updated on Aug 12, 2022, 2:10 PM UTC (70cdc6a)">Diff</a>