### PR TITLE
[Spec] Use USVString rather than DOMString

### DIFF
--- a/spec.bs
+++ b/spec.bs
@@ -544,7 +544,7 @@ Add the following to the [=registry of standardized payment methods=] in
         required sequence<BufferSource> credentialIds;
         required PaymentCredentialInstrument instrument;
         unsigned long timeout;
-        DOMString payeeName;
+        USVString payeeName;
         USVString payeeOrigin;
         AuthenticationExtensionsClientInputs extensions;
     };
@@ -874,7 +874,7 @@ directly; for authentication the extension can only be accessed via
       // Only used for authentication.
       USVString rpId;
       USVString topOrigin;
-      DOMString payeeName;
+      USVString payeeName;
       USVString payeeOrigin;
       PaymentCurrencyAmount total;
       PaymentCredentialInstrument instrument;
@@ -1038,7 +1038,7 @@ The {{CollectedClientPaymentData}} dictionary inherits from
     dictionary CollectedClientAdditionalPaymentData {
         required USVString rpId;
         required USVString topOrigin;
-        DOMString payeeName;
+        USVString payeeName;
         USVString payeeOrigin;
         required PaymentCurrencyAmount total;
         required PaymentCredentialInstrument instrument;
@@ -1084,7 +1084,7 @@ The following data structures are shared between registration and authentication
 
 <xmp class="idl">
     dictionary PaymentCredentialInstrument {
-        required DOMString displayName;
+        required USVString displayName;
         required USVString icon;
         boolean iconMustBeShown = true;
     };


### PR DESCRIPTION
Conversations with i18n representatives revealed that we likely don't need support for unpaired surrogates in the SPC API, and so it is simpler to align on USVStrings (rather than mixing DOMString and USVString).

Fixes https://github.com/w3c/secure-payment-confirmation/issues/208

- [x] Chrome implementation bug: https://crbug.com/1363469
- [x] WPT test changes: N/A (no tests explicitly test unpaired surrogates today, and I don't think there is sufficient value to develop tests that do)


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/secure-payment-confirmation/pull/211.html" title="Last updated on Sep 14, 2022, 4:03 AM UTC (d6a08bd)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/secure-payment-confirmation/211/50f0e7c...d6a08bd.html" title="Last updated on Sep 14, 2022, 4:03 AM UTC (d6a08bd)">Diff</a>