### PR TITLE
[Spec] Add SecurePaymentConfirmationRequest.locale

### DIFF
--- a/spec.bs
+++ b/spec.bs
@@ -547,6 +547,7 @@ Add the following to the [=registry of standardized payment methods=] in
         DOMString payeeName;
         USVString payeeOrigin;
         AuthenticationExtensionsClientInputs extensions;
+        sequence<USVString> localeHint;
     };
 </xmp>
 
@@ -588,6 +589,14 @@ members:
         credential(s). The caller does not need to specify the
         [[#sctn-payment-extension-registration| payment extension]]; it is added
         automatically.
+
+    :  <dfn>localeHint</dfn> member
+    :: An optional list of **TODO, ISO-something?** locale descriptors, in
+        decreasing order of priority, that act as a hint from the website as to
+        what locale the users experience on that website is currently in.
+
+        NOTE: **TODO** - add a note as to how this is distinct from the dir/lang
+              for specific input members.
 </dl>
 
 ### Payment Method additional data type ### {#sctn-payment-method-additional-data-type}
@@ -742,6 +751,11 @@ authentication:
     {{PaymentCredentialInstrument/iconMustBeShown}} must be `false` here as
     otherwise the [[#sctn-steps-to-check-if-a-payment-can-be-made|the steps
     to check if a payment can be made]] would have failed previously.
+
+The user agent MAY utilize the information in
+{{SecurePaymentConfirmationRequest/localeHint}}, if any, to display a UX in a
+matching language and locale-based formatting to that which the website is
+using for its interactions with the user.
 
 If the [=current transaction automation mode=] is not
 "{{TransactionAutomationMode/none}}", the user agent should first verify that

--- a/spec.bs
+++ b/spec.bs
@@ -35,6 +35,12 @@ spec: ECMAScript; urlPrefix: https://tc39.github.io/ecma262/#
             text: internal slot
             text: internal method
 
+spec: i18n-glossary; urlPrefix: https://w3c.github.io/i18n-glossary/
+    type: dfn
+        text: locale; url: locale
+        text: language priority list; url: language-priority-list
+        text: language negotiation; url: language-negotiation
+
 spec: payment-request; urlPrefix: https://w3c.github.io/payment-request/
     type: dfn
         text: payment method; url: dfn-payment-method
@@ -547,7 +553,7 @@ Add the following to the [=registry of standardized payment methods=] in
         DOMString payeeName;
         USVString payeeOrigin;
         AuthenticationExtensionsClientInputs extensions;
-        sequence<USVString> localeHint;
+        sequence<USVString> locale;
     };
 </xmp>
 
@@ -590,13 +596,17 @@ members:
         [[#sctn-payment-extension-registration| payment extension]]; it is added
         automatically.
 
-    :  <dfn>localeHint</dfn> member
-    :: An optional list of **TODO, ISO-something?** locale descriptors, in
-        decreasing order of priority, that act as a hint from the website as to
-        what locale the users experience on that website is currently in.
+    :  <dfn>locale</dfn> member
+    :: An optional list of well-formed [[BCP47]] language tags, in descending
+        order of priority, that identify the [=locale=] preferences of the
+        website, i.e. a [=language priority list=] [[RFC4647]], which the user
+        agent can use to perform [=language negotiation=] and locale-affected
+        formatting with the caller.
 
-        NOTE: **TODO** - add a note as to how this is distinct from the dir/lang
-              for specific input members.
+        NOTE: The {{SecurePaymentConfirmationRequest/locale}} is distinct from
+              language or direction metadata associated with specific input
+              members, in that it represents the caller's requested localized
+              experience rather than assertion about a specific string value.
 </dl>
 
 ### Payment Method additional data type ### {#sctn-payment-method-additional-data-type}
@@ -753,9 +763,9 @@ authentication:
     to check if a payment can be made]] would have failed previously.
 
 The user agent MAY utilize the information in
-{{SecurePaymentConfirmationRequest/localeHint}}, if any, to display a UX in a
-matching language and locale-based formatting to that which the website is
-using for its interactions with the user.
+{{SecurePaymentConfirmationRequest/locale}}, if any, to display a UX localized
+into a language and using locale-based formatting consistent with that of the
+website.
 
 If the [=current transaction automation mode=] is not
 "{{TransactionAutomationMode/none}}", the user agent should first verify that


### PR DESCRIPTION
This hint may (in an RFC2119 sense) be used by the browser to localize the SPC UX in order to match what the website is (reportedly) using in its interactions with the user.

Fixes https://github.com/w3c/secure-payment-confirmation/issues/209


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/secure-payment-confirmation/pull/212.html" title="Last updated on Sep 17, 2022, 2:34 AM UTC (ff031ed)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/secure-payment-confirmation/212/50f0e7c...ff031ed.html" title="Last updated on Sep 17, 2022, 2:34 AM UTC (ff031ed)">Diff</a>