### PR TITLE
[Spec] Expand 'payment attack' section for on-path attacks

### DIFF
--- a/spec.bs
+++ b/spec.bs
@@ -1374,8 +1374,13 @@ an unauthorized payment using Secure Payment Confirmation credentials
     assertion for the [=Relying Party=].
 * If the [=Relying Party=] is not expecting a transaction, it will reject the
     assertion.
-* If the [=Relying Party=] is expecting a transaction, it will detect an
-    unfamiliar `challenge` and reject the assertion.
+* If the [=Relying Party=] is expecting a transaction, it will detect at least
+    one of the following and reject the assertion:
+    * An incorrect {{CollectedClientData}}["{{CollectedClientData/challenge}}"],
+        if an attacker attempts to race against a valid ongoing payment.
+    * An incorrect {{CollectedClientData}}["{{CollectedClientData/origin}}"],
+        if an attacker attempts to sit between the user and a valid merchant
+        site and forward the assertion.
 
 ## Merchant-supplied authentication data ## {#sctn-security-merchant-data}
 


### PR DESCRIPTION
SPC already has mitigations against on-path attacks, where an attacker positions themselves between the user and a valid merchant website. However we did not previously explain how a Relying Party can detect this, so add a line about it.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/secure-payment-confirmation/pull/214.html" title="Last updated on Nov 9, 2022, 2:09 PM UTC (ea9b1b0)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/secure-payment-confirmation/214/63cfc2a...ea9b1b0.html" title="Last updated on Nov 9, 2022, 2:09 PM UTC (ea9b1b0)">Diff</a>