### PR TITLE
Add showOptOut option to spec

### DIFF
--- a/spec.bs
+++ b/spec.bs
@@ -1523,12 +1523,12 @@ NOTE: See [issue #77](https://github.com/w3c/secure-payment-confirmation/issues/
 
 ## User opt out ## {#sctn-user-opt-out}
 
-The API option {{SecurePaymentConfirmationRequest/showOptOut}} provides the
-developer a way to ask the user agent to provide the user with an opportunity to
-indicate they wish to opt out of the relying party's storage of information.
-When the user invokes this opt out, an {{OptOutError}} is returned to the caller
-to indicate the user's intent to opt out. It is then up to the caller to act on
-the opt out, e.g. by clearing payment information stored for the user.
+The API option {{SecurePaymentConfirmationRequest/showOptOut}} tells the
+user agent to provide a way for the user to indicate they wish to opt out of the
+relying party's storage of information. When the user invokes this opt out, an
+{{OptOutError}} is returned to the caller to indicate the user's intent to opt
+out. It is then up to the caller to act on the opt out, e.g. by clearing payment
+information stored for the user.
 
 Implementors must make sure that the return of an {{OptOutError}} does not
 reveal that the user has credentials but did not complete an authentication.

--- a/spec.bs
+++ b/spec.bs
@@ -792,15 +792,15 @@ considerations]]). The user agent should then bypass the above communication of
 information and gathering of user consent, and instead do the following based
 on the value of the [=current transaction automation mode=]:
 
-    : "{{TransactionAutomationMode/autoaccept}}"
+    : "{{TransactionAutomationMode/autoAccept}}"
     :: Act as if the user has seen the transaction details and accepted
         the authentication.
 
-    : "{{TransactionAutomationMode/autoreject}}"
+    : "{{TransactionAutomationMode/autoReject}}"
     :: Act as if the user has seen the transaction details and rejected
         the authentication.
 
-    : "{{TransactionAutomationMode/autooptout}}"
+    : "{{TransactionAutomationMode/autoOptOut}}"
     :: Act as if the user has seen the transaction details and indicated
         they want to opt out.
 
@@ -1262,9 +1262,9 @@ The <dfn>current transaction automation mode</dfn> tracks what
 <xmp class="idl">
     enum TransactionAutomationMode {
       "none",
-      "autoaccept",
-      "autoreject",
-      "autooptout"
+      "autoAccept",
+      "autoReject",
+      "autoOptOut"
     };
 </xmp>
 

--- a/spec.bs
+++ b/spec.bs
@@ -780,8 +780,9 @@ website.
 
 If {{SecurePaymentConfirmationRequest/showOptOut}} is `true`, the user agent
 MUST give the user the opportunity to indicate that they want to opt out of the
-process. If the user indicates that they wish to opt-out, then the user agent
-must reject the {{PaymentRequest/show|show()}} promise with an
+process for the {{SecurePaymentConfirmationRequest/rpId|given relying party}}.
+If the user indicates that they wish to opt-out, then the user agent must reject
+the {{PaymentRequest/show|show()}} promise with an
 "{{OptOutError}}" {{DOMException}}. See [[#sctn-user-opt-out]].
 
 If the [=current transaction automation mode=] is not

--- a/spec.bs
+++ b/spec.bs
@@ -93,11 +93,6 @@ spec:url; type:dfn; text:valid domain;
 }
 </pre>
 
-<!-- WPT tests that we do not want visible yet -->
-<wpt hidden>
-  authentication-optout.https.html
-</wpt>
-
 <div class="non-normative">
 
 # Introduction # {#sctn-intro}
@@ -784,6 +779,10 @@ process for the {{SecurePaymentConfirmationRequest/rpId|given relying party}}.
 If the user indicates that they wish to opt-out, then the user agent must reject
 the {{PaymentRequest/show|show()}} promise with an
 "{{OptOutError}}" {{DOMException}}. See [[#sctn-user-opt-out]].
+
+<wpt>
+  authentication-optout.https.html
+</wpt>
 
 If the [=current transaction automation mode=] is not
 "{{TransactionAutomationMode/none}}", the user agent should first verify that

--- a/spec.bs
+++ b/spec.bs
@@ -615,8 +615,9 @@ members:
               experience rather than assertion about a specific string value.
 
     :  <dfn>showOptOut</dfn> member
-    :: Whether the user should be shown a button to opt-out. Optional, default
-        false.
+    :: Whether the user should be given a chance to opt-out during the
+        [[#sctn-transaction-confirmation-ux|transaction confirmation UX]].
+        Optional, default false.
 </dl>
 
 ### Payment Method additional data type ### {#sctn-payment-method-additional-data-type}
@@ -778,9 +779,9 @@ into a language and using locale-based formatting consistent with that of the
 website.
 
 If {{SecurePaymentConfirmationRequest/showOptOut}} is `true`, the user agent
-MUST provide an additional button for the user to indicate that they want to
-opt out of the process. If this button is selected, then the user agent must
-reject the {{PaymentRequest/show|show()}} promise with an
+MUST give the user the opportunity to indicate that they want to opt out of the
+process. If the user indicates that they wish to opt-out, then the user agent
+must reject the {{PaymentRequest/show|show()}} promise with an
 "{{OptOutError}}" {{DOMException}}. See [[#sctn-user-opt-out]].
 
 If the [=current transaction automation mode=] is not
@@ -799,8 +800,8 @@ on the value of the [=current transaction automation mode=]:
         the authentication.
 
     : "{{TransactionAutomationMode/autooptout}}"
-    :: Act as if the user has seen the transaction details and clicked
-        the opt-out button.
+    :: Act as if the user has seen the transaction details and indicated
+        they want to opt out.
 
 ### Steps to respond to a payment request ### {#sctn-steps-to-respond-to-a-payment-request}
 
@@ -1523,16 +1524,16 @@ NOTE: See [issue #77](https://github.com/w3c/secure-payment-confirmation/issues/
 
 The API provides an option {{SecurePaymentConfirmationRequest/showOptOut}} for
 the developer to indicate to the user agent that that the user should be
-provided with a button to opt out of the process. When the button is selected,
-and an {{OptOutError}} is returned to the caller to indicate the user's intent
-to opt out, it is then up to the caller to act on the opt out, e.g. by clearing
-payment information stored for the user.
+provided with the option to opt out of the process. When the user invokes this
+opt out, and an {{OptOutError}} is returned to the caller to indicate the user's
+intent to opt out, it is then up to the caller to act on the opt out, e.g. by
+clearing payment information stored for the user.
 
-NOTE: This is not intended to be a mechanism to delete browser data or
-      credentials, it is for the developer to prompt for opt out via the user
-      agent. The user agent should make this clear to the user, for example with
-      some clarifying text: "This provider may have stored information about
-      your payment method, which you can request to be deleted."
+This is not intended to be a mechanism to delete browser data or credentials, it
+is for the developer to prompt for opt out via the user agent. The user agent
+should make this clear to the user, for example with some clarifying text:
+"This provider may have stored information about your payment method, which you
+can request to be deleted."
 
 # Accessibility Considerations # {#sctn-accessibility-considerations}
 

--- a/spec.bs
+++ b/spec.bs
@@ -1523,15 +1523,22 @@ NOTE: See [issue #77](https://github.com/w3c/secure-payment-confirmation/issues/
 
 ## User opt out ## {#sctn-user-opt-out}
 
-The API provides an option {{SecurePaymentConfirmationRequest/showOptOut}} for
-the developer to indicate to the user agent that that the user should be
-provided with the option to opt out of the process. When the user invokes this
-opt out, and an {{OptOutError}} is returned to the caller to indicate the user's
-intent to opt out, it is then up to the caller to act on the opt out, e.g. by
-clearing payment information stored for the user.
+The API option {{SecurePaymentConfirmationRequest/showOptOut}} provides the
+developer a way to ask the user agent to provide the user with an opportunity to
+indicate they wish to opt out of the relying party's storage of information.
+When the user invokes this opt out, an {{OptOutError}} is returned to the caller
+to indicate the user's intent to opt out. It is then up to the caller to act on
+the opt out, e.g. by clearing payment information stored for the user.
 
-This is not intended to be a mechanism to delete browser data or credentials, it
-is for the developer to prompt for opt out via the user agent. The user agent
+Implementors must make sure that the return of an {{OptOutError}} does not
+reveal that the user has credentials but did not complete an authentication.
+This can be mitigated by similar means as
+[[#sctn-privacy-probing-credential-ids]], e.g. by also providing the user an
+opportunity to opt out on the interstitial UX in the case where a credential
+match is not found.
+
+This is not intended to be a mechanism to delete browser data or credentials -
+it is for the developer to prompt for opt out via the user agent. The user agent
 should make this clear to the user, for example with some clarifying text:
 "This provider may have stored information about your payment method, which you
 can request to be deleted."

--- a/spec.bs
+++ b/spec.bs
@@ -559,6 +559,7 @@ Add the following to the [=registry of standardized payment methods=] in
         USVString payeeOrigin;
         AuthenticationExtensionsClientInputs extensions;
         sequence<USVString> locale;
+        boolean showOptOut;
     };
 </xmp>
 
@@ -612,6 +613,10 @@ members:
               language or direction metadata associated with specific input
               members, in that it represents the caller's requested localized
               experience rather than assertion about a specific string value.
+
+    :  <dfn>showOptOut</dfn> member
+    :: Whether the user should be shown a button to opt-out. Optional, default
+        false.
 </dl>
 
 ### Payment Method additional data type ### {#sctn-payment-method-additional-data-type}
@@ -772,6 +777,12 @@ The user agent MAY utilize the information in
 into a language and using locale-based formatting consistent with that of the
 website.
 
+If {{SecurePaymentConfirmationRequest/showOptOut}} is `true`, the user agent
+MUST provide an additional button for the user to indicate that they want to
+opt out of the process. If this button is selected, then the user agent must
+reject the {{PaymentRequest/show|show()}} promise with an
+"{{OptOutError}}" {{DOMException}}. See [[#sctn-user-opt-out]].
+
 If the [=current transaction automation mode=] is not
 "{{TransactionAutomationMode/none}}", the user agent should first verify that
 it is in an automation context (see [[WebDriver2#security|WebDriver's Security
@@ -786,6 +797,10 @@ on the value of the [=current transaction automation mode=]:
     : "{{TransactionAutomationMode/autoreject}}"
     :: Act as if the user has seen the transaction details and rejected
         the authentication.
+
+    : "{{TransactionAutomationMode/autooptout}}"
+    :: Act as if the user has seen the transaction details and clicked
+        the opt-out button.
 
 ### Steps to respond to a payment request ### {#sctn-steps-to-respond-to-a-payment-request}
 
@@ -1246,7 +1261,8 @@ The <dfn>current transaction automation mode</dfn> tracks what
     enum TransactionAutomationMode {
       "none",
       "autoaccept",
-      "autoreject"
+      "autoreject",
+      "autooptout"
     };
 </xmp>
 
@@ -1502,6 +1518,21 @@ give to the [=Relying Party=] (e.g., the credit card number).
 
 NOTE: See [issue #77](https://github.com/w3c/secure-payment-confirmation/issues/77)
       for discussion on possible spec changes related to this section.
+
+## User opt out ## {#sctn-user-opt-out}
+
+The API provides an option {{SecurePaymentConfirmationRequest/showOptOut}} for
+the developer to indicate to the user agent that that the user should be
+provided with a button to opt out of the process. When the button is selected,
+and an {{OptOutError}} is returned to the caller to indicate the user's intent
+to opt out, it is then up to the caller to act on the opt out, e.g. by clearing
+payment information stored for the user.
+
+NOTE: This is not intended to be a mechanism to delete browser data or
+      credentials, it is for the developer to prompt for opt out via the user
+      agent. The user agent should make this clear to the user, for example with
+      some clarifying text: "This provider may have stored information about
+      your payment method, which you can request to be deleted."
 
 # Accessibility Considerations # {#sctn-accessibility-considerations}
 


### PR DESCRIPTION
This PR adds spec text for a new showOptOut option in the SecurePaymentConfirmationRequest API. See the original proposal and discussion in #172. This spec change reflects the prototype currently implemented behind a flag in Chrome, which is available via origin trial and used in [this test page](https://rsolomakhin.github.io/pr/spc-opt-out/).

The OptOutError mentioned in this change is being added to WebIDL in https://github.com/whatwg/webidl/pull/1231.

Opt-out web platform test: https://github.com/web-platform-tests/wpt/pull/37012


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/nickburris/secure-payment-confirmation/pull/215.html" title="Last updated on Dec 9, 2022, 1:49 PM UTC (78e2553)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/secure-payment-confirmation/215/06a08c0...nickburris:78e2553.html" title="Last updated on Dec 9, 2022, 1:49 PM UTC (78e2553)">Diff</a>