### PR TITLE
Note in explainer re: user activation (removal)

### DIFF
--- a/explainer.md
+++ b/explainer.md
@@ -576,9 +576,22 @@ used according to this common pattern:
   the pre-authentication details with the assertion details to ensure that they
   align.
 
-**Click-jacking attack**
+**Lack of user activation requirement**
 
-Like Web Authentication, SPC does not require a user activation (although it used to; see [issue 216](https://github.com/w3c/secure-payment-confirmation/issues/216) for details on why it was part of the specification and why it was removed). Without a user activation requirement, there is a slightly increased risk that a malicious site might attempt to click-jack the user. To mitigate this risk, user agents can implement a delay between the display of the transaction dialog and enabling the "Verify" button.
+Like Web Authentication, SPC does not require a user activation (although it
+used to; see [issue 216](https://github.com/w3c/secure-payment-confirmation/issues/216)
+for details on why it was part of the specification and why it was removed).
+Without a user activation requirement, there is a slightly increased risk that a
+malicious site might attempt to spam or click-jack the user.
+
+In order to mitigate spam, the user agent may decide to enforce a user
+activation requirement after some threshold - for example, only allowing one
+activationless call per page load. To mitigate click-jacking attacks, the user agent
+may implement a time threshold in which clicks are ignored immediately after a
+dialog is shown.
+
+Another relevant mitigation exists; the spec requires that the document must be
+visible in order to initiate Secure Payment Confirmation.
 
 ## Privacy Considerations
 

--- a/explainer.md
+++ b/explainer.md
@@ -576,6 +576,10 @@ used according to this common pattern:
   the pre-authentication details with the assertion details to ensure that they
   align.
 
+**Click-jacking attack**
+
+Like Web Authentication, SPC does not require a user activation (although it used to; see [issue 216](https://github.com/w3c/secure-payment-confirmation/issues/216) for details on why it was part of the specification and why it was removed). Without a user activation requirement, there is a slightly increased risk that a malicious site might attempt to click-jack the user. To mitigate this risk, user agents can implement a delay between the display of the transaction dialog and enabling the "Verify" button.
+
 ## Privacy Considerations
 
 On top of the [WebAuthn privacy considerations], there are a few considerations


### PR DESCRIPTION
Per TAG review [1], adding a note to Security Considerations about the click-jacking risk and how the browser mitigates it.

[1] https://github.com/w3ctag/design-reviews/issues/802#issuecomment-1422225875


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/secure-payment-confirmation/pull/230.html" title="Last updated on Apr 24, 2023, 2:58 PM UTC (f323fbe)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/secure-payment-confirmation/230/1565e06...f323fbe.html" title="Last updated on Apr 24, 2023, 2:58 PM UTC (f323fbe)">Diff</a>