### PR TITLE
Use an hyphenated version of the SPC Transaction Mode enumeration values

### DIFF
--- a/spec.bs
+++ b/spec.bs
@@ -792,15 +792,15 @@ should then bypass the above communication of information and gathering of user
 consent, and instead do the following based on the value of the [=current
 transaction automation mode=]:
 
-    : "`autoAccept`"
+    : "`auto-accept`"
     :: Act as if the user has seen the transaction details and accepted
         the authentication.
 
-    : "`autoReject`"
+    : "`auto-reject`"
     :: Act as if the user has seen the transaction details and rejected
         the authentication.
 
-    : "`autoOptOut`"
+    : "`auto-opt-out`"
     :: Act as if the user has seen the transaction details and indicated
         they want to opt out.
 
@@ -1283,8 +1283,8 @@ The [=remote end steps=] are:
 1. Let |mode| be the result of [=getting a property=] named `"mode"` from
     |parameters|.
 
-1. If |mode| is [=undefined=] or is not one of "`autoAccept`", "`autoReject`",
-    or "`autoOptOut`", return a [=WebDriver error=] with [=WebDriver error
+1. If |mode| is [=undefined=] or is not one of "`auto-accept`", "`auto-reject`",
+    or "`auto-opt-out`", return a [=WebDriver error=] with [=WebDriver error
     code=] [=invalid argument=].
 
 1. Set the [=current transaction automation mode=] to |mode|.


### PR DESCRIPTION
According to the [Web Platform Design Principles ](https://w3ctag.github.io/design-principles/#casing-rules) the enumeration values should be defined in the "Lowercase, dash-delimited" form. 

I've recently defined a new Web Driver command, inspired by the [Set SPC Transaction Mode](https://w3c.github.io/secure-payment-confirmation/#set-spc-transaction-mode) command defined in this spec, for the Custom Handler feature. The new  [Set RPH Registration Mode](https://html.spec.whatwg.org/multipage/system-state.html#set-rph-registration-mode) command values are defined according to the mentioned rules: auto-accept and auto-reject. 

Is there any reason or specific need in the spec to avoid following the design principle casting rules ?  Would make sense to have a common solution for both web driver commands.

As a mater of fact, I've recently landed a [CL](https://chromium-review.googlesource.com/c/chromium/src/+/4218519) for the Chrome Dev Tools so that both command's implementation for Chromedriver use the same enum. This shared enum still uses the camelCase version, so it'd should be a matter of changing it to use the hyphenated version instead.