### PR TITLE
Add I18N Considerations section

### DIFF
--- a/spec.bs
+++ b/spec.bs
@@ -35,7 +35,7 @@ spec: ECMAScript; urlPrefix: https://tc39.github.io/ecma262/#
             text: internal slot
             text: internal method
 
-spec: i18n-glossary; urlPrefix: https://w3c.github.io/i18n-glossary/
+spec: i18n-glossary; urlPrefix: https://www.w3.org/TR/i18n-glossary/
     type: dfn
         text: locale; url: locale
 
@@ -1543,15 +1543,16 @@ and [=payment request accessibility considerations|PaymentRequest's Accessibilit
 
 # Internationalization Considerations # {#sctn-i18n-considerations}
 
-Callers of the API may express preferences for localized transaction
-dialog experiences via the {{SecurePaymentConfirmationRequest/locale}} member.
+Callers of the API should express the desired [=locale=] of the
+transaction dialog as well as the localization of any displayable
+strings via the {{SecurePaymentConfirmationRequest/locale}} member. In
+general this member should match the localization of the page where
+the request originates (such as by querying the `lang` attribute of
+the button triggering the request).
 
 This specification does not (yet) include mechanisms for callers to
 associate language or direction metadata with the displayable strings
 they provide as input to the API (e.g., {{PaymentCredentialInstrument/displayName}}).
-To track progress on on this topic see <a
-href="https://github.com/w3c/secure-payment-confirmation/issues/93">issue
-93</a>.
 
 In the meantime, callers of the API should consider the following:
 


### PR DESCRIPTION
Seeks to address #205.

Summary of structure of this pull request:

* Add Internationalization Considerations Section.
* Mention there role of locale member (and link to this section from locale definition)
* Point out that locale does not serve same role as language and bidi metadata, and that the W3C community is still working on that issue.
* Following guidance from @aphillips, cover topics for callers of the API in the meantime, namely (1) consistency between locale and any input displayable strings and (2) clean bidi with reference to an I18N WG document.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/secure-payment-confirmation/pull/232.html" title="Last updated on Mar 8, 2023, 3:49 PM UTC (e52aff5)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/secure-payment-confirmation/232/1565e06...e52aff5.html" title="Last updated on Mar 8, 2023, 3:49 PM UTC (e52aff5)">Diff</a>