### PR TITLE
Add isSecurePaymentConfirmationAvailable API to spec

### DIFF
--- a/spec.bs
+++ b/spec.bs
@@ -637,8 +637,8 @@ partial interface PaymentRequest {
 <dl dfn-type="attribute" dfn-for="PaymentRequest">
     :   {{PaymentRequest/isSecurePaymentConfirmationAvailable()}}
     ::  Upon invocation, a promise is returned that resolves with a value of
-        `true` if the user agent believes that the Secure Payment Confirmation
-        feature is available, or `false` otherwise.
+        `true` if the Secure Payment Confirmation feature is available, or
+        `false` otherwise.
 </dl>
 
 This allows a developer to perform the following check when deciding whether to

--- a/spec.bs
+++ b/spec.bs
@@ -624,7 +624,7 @@ The [=payment method additional data type=] for this payment method is
 
 ### Checking if Secure Payment Confirmation is available ### {#sctn-secure-payment-confirmation-available-api}
 
-A static API is added to {{PaymentRequest}} in order to provide develoeprs a
+A static API is added to {{PaymentRequest}} in order to provide developers a
 simplified method of checking whether Secure Payment Confirmation is available.
 
 <xmp class="idl">

--- a/spec.bs
+++ b/spec.bs
@@ -642,7 +642,7 @@ partial interface PaymentRequest {
 This allows a developer to perform the following check when deciding whether to
 initiate a SPC flow:
 
-<pre class="example" id="registration-example" highlight="js">
+<pre class="example" id="available-example" highlight="js">
 const spcAvailable =
     PaymentRequest &&
     PaymentRequest.isSecurePaymentConfirmationAvailable &&

--- a/spec.bs
+++ b/spec.bs
@@ -420,10 +420,6 @@ try {
 }
 </pre>
 
-NOTE: The use of the static {{PaymentRequest/isSecurePaymentConfirmationAvailable}} method is recommended for
-      SPC feature detection, instead of calling {{PaymentRequest/canMakePayment}} on an already-constructed
-      PaymentRequest object.
-
 # Terminology # {#sctn-terminology}
 
 : <dfn export>SPC Credential</dfn>
@@ -654,6 +650,10 @@ const spcAvailable =
     PaymentRequest.isSecurePaymentConfirmationAvailable &&
     await PaymentRequest.isSecurePaymentConfirmationAvailable();
 </pre>
+
+NOTE: The use of the static {{PaymentRequest/isSecurePaymentConfirmationAvailable}} method is recommended for
+      SPC feature detection, instead of calling {{PaymentRequest/canMakePayment}} on an already-constructed
+      PaymentRequest object.
 
 ### Steps to validate payment method data ### {#sctn-steps-to-validate-payment-method-data}
 

--- a/spec.bs
+++ b/spec.bs
@@ -363,7 +363,16 @@ The sample code for authenticating the user follows. Note that the example code
 presumes access to await/async, for easier to read promise handling.
 
 <pre class="example" id="authentication-example" highlight="js">
-if (!window.PaymentRequest) { /* PaymentRequest not available; merchant should fallback to traditional flows */ }
+/* isSecurePaymentConfirmationAvailable indicates whether the browser */
+/* supports SPC. It does not indicate whether the user has a credential */
+/* ready to go on this device. */
+const spcAvailable =
+  PaymentRequest &&
+  PaymentRequest.isSecurePaymentConfirmationAvailable &&
+  await PaymentRequest.isSecurePaymentConfirmationAvailable();
+if (!spcAvailable) {
+  /* Browser does not support SPC; merchant should fallback to traditional flows. */
+}
 
 const request = new PaymentRequest([{
   supportedMethods: "secure-payment-confirmation",
@@ -398,17 +407,7 @@ const request = new PaymentRequest([{
     },
   });
 
-  /* isSecurePaymentConfirmationAvailable indicates whether the browser */
-  /* supports SPC. It does not indicate whether the user has a credential */
-  /* ready to go on this device. */
-
 try {
-  const spcAvailable =
-    PaymentRequest &&
-    PaymentRequest.isSecurePaymentConfirmationAvailable &&
-    await PaymentRequest.isSecurePaymentConfirmationAvailable();
-  if (!spcAvailable) { /* Browser does not support SPC. Handle error. */ }
-
   const response = await request.show();
   await response.complete('success');
 
@@ -420,6 +419,10 @@ try {
   /* SPC cannot be used; merchant should fallback to traditional flows */
 }
 </pre>
+
+NOTE: The use of the static {{PaymentRequest/isSecurePaymentConfirmationAvailable}} method is recommended for
+      SPC feature detection, instead of calling {{PaymentRequest/canMakePayment}} on an already-constructed
+      PaymentRequest object.
 
 # Terminology # {#sctn-terminology}
 

--- a/spec.bs
+++ b/spec.bs
@@ -398,13 +398,16 @@ const request = new PaymentRequest([{
     },
   });
 
-  /* canMakePayment indicates whether the browser supports SPC. */
-  /* canMakePayment does not indicate whether the user has a credential */
+  /* isSecurePaymentConfirmationAvailable indicates whether the browser */
+  /* supports SPC. It does not indicate whether the user has a credential */
   /* ready to go on this device. */
 
 try {
-  const canMakePayment = await request.canMakePayment();
-  if (!canMakePayment) { /* Browser does not support SPC. Handle error. */ }
+  const spcAvailable =
+    PaymentRequest &&
+    PaymentRequest.isSecurePaymentConfirmationAvailable &&
+    await PaymentRequest.isSecurePaymentConfirmationAvailable();
+  if (!spcAvailable) { /* Browser does not support SPC. Handle error. */ }
 
   const response = await request.show();
   await response.complete('success');

--- a/spec.bs
+++ b/spec.bs
@@ -622,6 +622,33 @@ members:
 The [=payment method additional data type=] for this payment method is
 {{SecurePaymentConfirmationRequest}}.
 
+### Checking if Secure Payment Confirmation is available ### {#sctn-secure-payment-confirmation-available-api}
+
+A static API is added to {{PaymentRequest}} in order to provide develoeprs a
+simplified method of checking whether Secure Payment Confirmation is available.
+
+<xmp class="idl">
+partial interface PaymentRequest {
+    static Promise<boolean> isSecurePaymentConfirmationAvailable();
+};
+</xmp>
+<dl dfn-type="attribute" dfn-for="PaymentRequest">
+    :   {{PaymentRequest/isSecurePaymentConfirmationAvailable()}}
+    ::  Upon invocation, a promise is returned that resolves with a value of
+        `true` if the user agent believes that the Secure Payment Confirmation
+        feature is available, or `false` otherwise.
+</dl>
+
+This allows a developer to perform the following check when deciding whether to
+initiate a SPC flow:
+
+<pre class="example" id="registration-example" highlight="js">
+const spcAvailable =
+    PaymentRequest &&
+    PaymentRequest.isSecurePaymentConfirmationAvailable &&
+    await PaymentRequest.isSecurePaymentConfirmationAvailable();
+</pre>
+
 ### Steps to validate payment method data ### {#sctn-steps-to-validate-payment-method-data}
 
 The [=steps to validate payment method data=] for this payment method, for an


### PR DESCRIPTION
This adds spec text for an API for developers to more easily check whether SPC is available. Fixes #81. One question is whether the spec should further clarify what it means for SPC to be available, but I'm not sure how we can say that without being too implementation specific.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/nickburris/secure-payment-confirmation/pull/233.html" title="Last updated on Apr 11, 2023, 7:31 PM UTC (484e07a)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/secure-payment-confirmation/233/568fbab...nickburris:484e07a.html" title="Last updated on Apr 11, 2023, 7:31 PM UTC (484e07a)">Diff</a>