### PR TITLE
[Spec] Only allow SPC authentication if in a foreground tab

### DIFF
--- a/spec.bs
+++ b/spec.bs
@@ -35,6 +35,10 @@ spec: ECMAScript; urlPrefix: https://tc39.github.io/ecma262/#
             text: internal slot
             text: internal method
 
+spec: html-document-sequences; urlPrefix: https://html.spec.whatwg.org/multipage/document-sequences.html
+    type: dfn
+        text: system visibility state; url: system-visibility-state
+
 spec: i18n-glossary; urlPrefix: https://www.w3.org/TR/i18n-glossary/
     type: dfn
         text: locale; url: locale
@@ -81,6 +85,7 @@ spec: webdriver; urlPrefix: https://w3c.github.io/webdriver/
 
 <pre class="link-defaults">
 spec:url; type:dfn; text:valid domain;
+spec:html; type:dfn; for:navigable; text:traversable navigable
 </pre>
 
 <pre class="biblio">
@@ -683,6 +688,12 @@ input {{SecurePaymentConfirmationRequest}} |data|, are:
   authentication-icon-data-url.https.html
   authentication-rejected.https.html
 </wpt>
+
+1. If the [=system visibility state=] of the [=top-level browsing context's=]
+     [=traversable navigable=] is not `"visible"`, return `false`.
+
+        Note: This prevents SPC from being triggered from e.g. a background tab
+        or minimized window.
 
 1. If |data|["{{SecurePaymentConfirmationRequest/payeeOrigin}}"] is present:
 

--- a/spec.bs
+++ b/spec.bs
@@ -685,14 +685,14 @@ input {{SecurePaymentConfirmationRequest}} |data|, are:
 </wpt>
 
 1. If [=this's=] [=relevant global object=]'s [=associated Document=]'s
-     [=Document/visibility state=] is not `"visible"`, return `false`.
+    [=Document/visibility state=] is not `"visible"`, return `false`.
 
-        Note: This prevents SPC from being triggered from a background tab,
-        minimized window, or other similar hidden situations.
+    Note: This prevents SPC from being triggered from a background tab,
+    minimized window, or other similar hidden situations.
 
-        Issue: [=this=] is the {{PaymentRequest}} whose {{PaymentRequest/show()}}
-        method invoked these [=steps to check if a payment can be made=]. It
-        would be better to run this step directly from {{PaymentRequest/show()}}.
+    Issue: [=this=] is the {{PaymentRequest}} whose {{PaymentRequest/show()}}
+    method invoked these [=steps to check if a payment can be made=]. It
+    would be better to run this step directly from {{PaymentRequest/show()}}.
 
 1. If |data|["{{SecurePaymentConfirmationRequest/payeeOrigin}}"] is present:
 

--- a/spec.bs
+++ b/spec.bs
@@ -35,10 +35,6 @@ spec: ECMAScript; urlPrefix: https://tc39.github.io/ecma262/#
             text: internal slot
             text: internal method
 
-spec: html-document-sequences; urlPrefix: https://html.spec.whatwg.org/multipage/document-sequences.html
-    type: dfn
-        text: system visibility state; url: system-visibility-state
-
 spec: i18n-glossary; urlPrefix: https://www.w3.org/TR/i18n-glossary/
     type: dfn
         text: locale; url: locale
@@ -85,7 +81,6 @@ spec: webdriver; urlPrefix: https://w3c.github.io/webdriver/
 
 <pre class="link-defaults">
 spec:url; type:dfn; text:valid domain;
-spec:html; type:dfn; for:navigable; text:traversable navigable
 </pre>
 
 <pre class="biblio">
@@ -689,11 +684,15 @@ input {{SecurePaymentConfirmationRequest}} |data|, are:
   authentication-rejected.https.html
 </wpt>
 
-1. If the [=system visibility state=] of the [=top-level browsing context's=]
-     [=traversable navigable=] is not `"visible"`, return `false`.
+1. If [=this's=] [=relevant global object=]'s [=associated Document=]'s
+     [=Document/visibility state=] is not `"visible"`, return `false`.
 
-        Note: This prevents SPC from being triggered from e.g. a background tab
-        or minimized window.
+        Note: This prevents SPC from being triggered from a background tab,
+        minimized window, or other similar hidden situations.
+
+        Issue: [=this=] is the {{PaymentRequest}} whose {{PaymentRequest/show()}}
+        method invoked these [=steps to check if a payment can be made=]. It
+        would be better to run this step directly from {{PaymentRequest/show()}}.
 
 1. If |data|["{{SecurePaymentConfirmationRequest/payeeOrigin}}"] is present:
 


### PR DESCRIPTION
During PING review of the pre-CR changes to SPC, the PING raised a concern that removing the user activation requirement (see https://github.com/w3c/secure-payment-confirmation/pull/236) could lead to sites triggering SPC from a background tab. This PR adds logic to the [steps to check if a payment can be made](https://w3c.github.io/payment-request/#dfn-steps-to-check-if-a-payment-can-be-made) to disallow background tabs (and minimized-windows/etc).

It is likely that eventually we will want this specified in Payment Request instead, both because it will be clearer spec text (here we have to refer to a `this` that is actually from the Payment Request spec), and also because we (in Chrome) already do (afaik) reject Payment Requests from background tabs. (Which is allowable by abusing the Payment Request spec text that says a user agent may reject show() for any security reason).

- [ ] [WPT tests](https://github.com/web-platform-tests/wpt/pull/39507) - not yet landed
- [x] Chromium implementation - already done, Chromium doesn't allow Payment Request in a background tab already today
- [x] Other browsers - N/A, no other browser currently implementing SPC.

Fixes https://github.com/w3c/secure-payment-confirmation/issues/237


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/secure-payment-confirmation/pull/238.html" title="Last updated on Apr 13, 2023, 2:17 PM UTC (799f55a)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/secure-payment-confirmation/238/9b4ec43...799f55a.html" title="Last updated on Apr 13, 2023, 2:17 PM UTC (799f55a)">Diff</a>