### PR TITLE
Editorial: Mention WebAuthn Level 3 is expected to support cross-orgin registration

### DIFF
--- a/spec.bs
+++ b/spec.bs
@@ -483,13 +483,16 @@ specified.
   enrollment-in-iframe.sub.https.html
 </wpt>
 
-Note: In this specification we define an extension in order to allow (1)
-      credential creation in a cross-origin iframe (which WebAuthn does not yet
-      allow) and (2) the browser to cache SPC credentials in the absence of
-      [[webauthn-conditional-ui|Conditional UI]]. If these capabilities are
-      available in future versions of WebAuthn, we may remove the requirement
-      for the extension from SPC. Note that SPC credentials (with the extension)
-      are otherwise full-fledged WebAuthn credentials.
+Note: In this specification we define an extension in order to allow
+      (1) credential creation in a cross-origin iframe (which WebAuthn
+      Levels 1 and 2 do not allow, but Level 3 <a
+      href="https://github.com/w3c/webauthn/pull/1801">is expected to
+      allow</a>) and (2) the browser to cache SPC credentials in the
+      absence of [[webauthn-conditional-ui|Conditional UI]]. If these
+      capabilities are available in future versions of WebAuthn, we
+      may remove the requirement for the extension from SPC. Note that
+      SPC credentials (with the extension) are otherwise full-fledged
+      WebAuthn credentials.
 
 # Authentication # {#sctn-authentication}
 


### PR DESCRIPTION
Add to an informative Note that WebAuthn Levels 1 and 2 do not support cross-origin registration, but level 3 is expected to, and link to pull request:
 https://github.com/w3c/webauthn/pull/1801


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/secure-payment-confirmation/pull/243.html" title="Last updated on May 10, 2023, 7:59 PM UTC (058f277)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/secure-payment-confirmation/243/8efa6ae...058f277.html" title="Last updated on May 10, 2023, 7:59 PM UTC (058f277)">Diff</a>