### PR TITLE
[Spec] Remove a redundant TODO

### DIFF
--- a/spec.bs
+++ b/spec.bs
@@ -966,8 +966,6 @@ directly; for authentication the extension can only be accessed via
       :  <dfn>isPayment</dfn> member
       :: Indicates that the extension is active.
 
-        <div class="note">**TODO**: Find a better way to do this. Needed currently because other members are auth-time only.</div>
-
       :  <dfn>rpId</dfn> member
       :: The [=Relying Party=] id of the credential(s) being used. Only used at authentication time; not registration.
 


### PR DESCRIPTION
The TODO to remove the 'isPayment' method is redundant. As long as we have a create-time extension, we need some sort of member to set in the dictionary, and the boolean 'isPayment' fits the same pattern as other extensions use in WebAuthn (e.g., see the credProps extension -
https://w3c.github.io/webauthn/#sctn-authenticator-credential-properties-extension)


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/secure-payment-confirmation/pull/244.html" title="Last updated on May 23, 2023, 4:28 PM UTC (a1a1980)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/secure-payment-confirmation/244/f1f750a...a1a1980.html" title="Last updated on May 23, 2023, 4:28 PM UTC (a1a1980)">Diff</a>