### PR TITLE
[Spec] Fix TODO to modify Payment Request constructor

### DIFF
--- a/spec.bs
+++ b/spec.bs
@@ -545,7 +545,7 @@ Add the following to the [=registry of standardized payment methods=] in
 In the steps for the {{PaymentRequest/constructor|PaymentRequest object's constructor}},
 add a new step after step 4.3:
 
-4. Process payment methods: *[steps 1-3 elided]*
+4. Process payment methods: *[sub-steps 1-3 elided]*
 
     4. If |seenPMIs| contains "[=secure-payment-confirmation=]" and the size
         of |seenPMIs| is greater than 1, throw a {{RangeError}}.

--- a/spec.bs
+++ b/spec.bs
@@ -547,6 +547,16 @@ Add the following to the [=registry of standardized payment methods=] in
     : "[=secure-payment-confirmation=]"
     :: The <a href="https://w3c.github.io/secure-payment-confirmation/">Secure Payment Confirmation</a> specification.
 
+### Modification of Payment Request constructor ### {#sctn-modify-payment-request-constructor}
+
+In the specs for the {{PaymentRequest/constructor|PaymentRequest object's constructor}},
+add a new step after step 4.3:
+
+4. Process payment methods: *[steps 1-3 elided]*
+
+    4. If |seenPMIs| contains "[=secure-payment-confirmation=]" and the size
+        of |seenPMIs| is greater than 1, throw a {{RangeError}}.
+
 ### Modification of user activation requirement ### {#sctn-modify-user-activation-requirement}
 
 In the steps for the {{PaymentRequest/show|PaymentRequest.show()}} method,

--- a/spec.bs
+++ b/spec.bs
@@ -527,13 +527,6 @@ Request. We therefore expect (without a concrete timeline) that SPC will move
 away from its Payment Request origins. For developers, this should improve
 feature detection, invocation, and other aspects of the API.
 
-<div class="note">
-**TODO**: This specification also needs to constrain
-{{PaymentRequest/constructor|PaymentRequest's constructor}} somehow, to enforce
-that when "[=secure-payment-confirmation=]" is used exactly one method is
-given.
-</div>
-
 ### Payment Method Identifier ### {#sctn-payment-method-identifier}
 
 The [=standardized payment method identifier=] for the [=Secure Payment

--- a/spec.bs
+++ b/spec.bs
@@ -542,7 +542,7 @@ Add the following to the [=registry of standardized payment methods=] in
 
 ### Modification of Payment Request constructor ### {#sctn-modify-payment-request-constructor}
 
-In the specs for the {{PaymentRequest/constructor|PaymentRequest object's constructor}},
+In the steps for the {{PaymentRequest/constructor|PaymentRequest object's constructor}},
 add a new step after step 4.3:
 
 4. Process payment methods: *[steps 1-3 elided]*

--- a/spec.bs
+++ b/spec.bs
@@ -545,7 +545,7 @@ Add the following to the [=registry of standardized payment methods=] in
 In the steps for the {{PaymentRequest/constructor|PaymentRequest object's constructor}},
 add a new step after step 4.3:
 
-4. Process payment methods: *[sub-steps 1-3 elided]*
+4. Process payment methods: *[substeps 1-3 elided]*
 
     4. If |seenPMIs| contains "[=secure-payment-confirmation=]" and the size
         of |seenPMIs| is greater than 1, throw a {{RangeError}}.


### PR DESCRIPTION
This CL fixes a long overdue TODO to modify the PaymentRequest object's
constructor in order to make sure that if SPC is specified, then it is the only
specified payment method.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/secure-payment-confirmation/pull/247.html" title="Last updated on May 25, 2023, 4:13 PM UTC (98bf6fd)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/secure-payment-confirmation/247/c3f07d2...98bf6fd.html" title="Last updated on May 25, 2023, 4:13 PM UTC (98bf6fd)">Diff</a>