### PR TITLE
Revert "[Spec] Only allow SPC authentication if in a foreground tab (…

### DIFF
--- a/spec.bs
+++ b/spec.bs
@@ -1463,9 +1463,10 @@ on the current page. In order to mitigate click-jacking attacks, the user agent
 may implement a time threshold in which clicks are ignored immediately after a
 dialog is shown.
 
-Another relevant mitigation exists in step 1 of
-[[#sctn-steps-to-check-if-a-payment-can-be-made]], where the document must be
-visible in order to initiate Secure Payment Confirmation.
+Another relevant mitigation exists in
+{{PaymentRequest/show()|PaymentRequest.show()}}: the Payment Request API
+requires the document to be visible, and thus SPC cannot be triggered from a
+background tab, minimized window, or other similar hidden situations.
 
 # Privacy Considerations # {#sctn-privacy-considerations}
 


### PR DESCRIPTION
…#238)"

This reverts commits 4a9d88372d272821da7a28eb1f1d0ce7793b9acf and fd37ebed9dace990363f9d39510345288d57f103

This behavior is now spec'd in Payment Request itself as of https://github.com/w3c/payment-request/commit/cce8f5e3c78ee9901a6a216527559568b98636bb,
and so does not need to additionally be spec'd in SPC.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/secure-payment-confirmation/pull/249.html" title="Last updated on May 30, 2023, 2:09 PM UTC (2b61d55)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/secure-payment-confirmation/249/5e06e9a...2b61d55.html" title="Last updated on May 30, 2023, 2:09 PM UTC (2b61d55)">Diff</a>