### PR TITLE
Remove note around Payment extension

### DIFF
--- a/spec.bs
+++ b/spec.bs
@@ -1011,12 +1011,7 @@ directly; for authentication the extension can only be accessed via
     </dl>
 
 :  <dfn export>Client extension processing ([=registration extension|registration=])</dfn>
-:: Note: Reading [[webauthn-3]] literally, these steps don't work; extensions
-    are injected at step 12 of `[[Create]]` and cannot really modify anything.
-    However other extensions ignore that entirely and assume they can modify any
-    part of any WebAuthn algorithm!
-
-    When [[webauthn-3#sctn-createCredential|creating a new credential]]:
+:: When [[webauthn-3#sctn-createCredential|creating a new credential]]:
 
     1. Modify step 2 (the check for *sameOriginWithAncestors*) as follows:
 


### PR DESCRIPTION
Propose to remote note based on IANA registry conversation.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/secure-payment-confirmation/pull/255.html" title="Last updated on Jul 31, 2023, 1:58 PM UTC (b12ed5b)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/secure-payment-confirmation/255/200fb61...b12ed5b.html" title="Last updated on Jul 31, 2023, 1:58 PM UTC (b12ed5b)">Diff</a>