### PR TITLE
(Informative) Note about WebAuthn registration display behaviors (as of Oct 2023)

### DIFF
--- a/spec.bs
+++ b/spec.bs
@@ -70,7 +70,7 @@ spec: web-authn; urlPrefix: https://w3c.github.io/webauthn/
         text: registration extension; url: registration-extension
         text: authentication extension; url: authentication-extension
         text: extension identifier; url: extension-identifier
-	text: user member; url: publickeycredentialcreationoptions-user
+        text: user member; url: publickeycredentialcreationoptions-user
 
 spec: webdriver; urlPrefix: https://w3c.github.io/webdriver/
     type: dfn

--- a/spec.bs
+++ b/spec.bs
@@ -70,6 +70,7 @@ spec: web-authn; urlPrefix: https://w3c.github.io/webauthn/
         text: registration extension; url: registration-extension
         text: authentication extension; url: authentication-extension
         text: extension identifier; url: extension-identifier
+	text: user member; url: publickeycredentialcreationoptions-user
 
 spec: webdriver; urlPrefix: https://w3c.github.io/webdriver/
     type: dfn
@@ -500,6 +501,16 @@ Note: In this specification we define an extension in order to allow
       may remove the requirement for the extension from SPC. Note that
       SPC credentials (with the extension) are otherwise full-fledged
       WebAuthn credentials.
+
+Note: At registration time, Web Authentication requires both
+      {{PaymentCredentialInstrument/name}} and
+      {{PaymentCredentialInstrument/displayName}}, although per the
+      definition of the [=user member=], implementations are not
+      required to display either of them in subsequent authentication
+      ceremonies. Of the two, as of October 2023
+      {{PaymentCredentialInstrument/displayName}} is shown more
+      consistently. Developers should continue to monitor
+      implementations.
 
 # Authentication # {#sctn-authentication}
 

--- a/spec.bs
+++ b/spec.bs
@@ -70,7 +70,7 @@ spec: web-authn; urlPrefix: https://w3c.github.io/webauthn/
         text: registration extension; url: registration-extension
         text: authentication extension; url: authentication-extension
         text: extension identifier; url: extension-identifier
-        text: user member; url: publickeycredentialcreationoptions-user
+        text: user member; url: dom-publickeycredentialcreationoptions-user
 
 spec: webdriver; urlPrefix: https://w3c.github.io/webdriver/
     type: dfn

--- a/spec.bs
+++ b/spec.bs
@@ -508,7 +508,7 @@ Note: At registration time, Web Authentication requires both
       definition of the [=user member=], implementations are not
       required to display either of them in subsequent authentication
       ceremonies. Of the two, as of October 2023
-      {{PublicKeyCredentialUserEntity/displayName}} is shown more
+      {{PublicKeyCredentialEntity/name}} is shown more
       consistently. Developers should continue to monitor
       implementations.
 

--- a/spec.bs
+++ b/spec.bs
@@ -503,12 +503,12 @@ Note: In this specification we define an extension in order to allow
       WebAuthn credentials.
 
 Note: At registration time, Web Authentication requires both
-      {{PaymentCredentialInstrument/name}} and
-      {{PaymentCredentialInstrument/displayName}}, although per the
+      {{PublicKeyCredentialEntity/name}} and
+      {{PublicKeyCredentialUserEntity/displayName}}, although per the
       definition of the [=user member=], implementations are not
       required to display either of them in subsequent authentication
       ceremonies. Of the two, as of October 2023
-      {{PaymentCredentialInstrument/displayName}} is shown more
+      {{PublicKeyCredentialUserEntity/displayName}} is shown more
       consistently. Developers should continue to monitor
       implementations.
 


### PR DESCRIPTION
Based on TPAC discussion of differing implementation behaviors, it could be useful to let SPC API users know about current implementation state. We plan to discuss this with the Web Authentication WG as well.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/secure-payment-confirmation/pull/261.html" title="Last updated on Oct 18, 2023, 2:34 PM UTC (07a5911)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/secure-payment-confirmation/261/591428a...07a5911.html" title="Last updated on Oct 18, 2023, 2:34 PM UTC (07a5911)">Diff</a>