### PR TITLE
Add reference to timeout information in WebAuthn 

### DIFF
--- a/spec.bs
+++ b/spec.bs
@@ -624,8 +624,8 @@ members:
     :  <dfn>timeout</dfn> member
     :: The number of milliseconds before the request to sign the transaction
         details times out. At most 1 hour. Default values and the range of
-	allowed values is defined by the user agent. Web Authentication
-	provides [webauthn-3#sctn-createCredential|additional timeout guidance].
+        allowed values is defined by the user agent. Web Authentication
+        provides [webauthn-3#sctn-createCredential|additional timeout guidance].
 
     :  <dfn>payeeName</dfn> member
     :: The display name of the payee that this SPC call is for (e.g., the

--- a/spec.bs
+++ b/spec.bs
@@ -623,7 +623,9 @@ members:
 
     :  <dfn>timeout</dfn> member
     :: The number of milliseconds before the request to sign the transaction
-        details times out. At most 1 hour.
+        details times out. At most 1 hour. Default values and the range of
+	allowed values is defined by the user agent. Web Authentication
+	provides [webauthn-3#sctn-createCredential|additional timeout guidance].
 
     :  <dfn>payeeName</dfn> member
     :: The display name of the payee that this SPC call is for (e.g., the


### PR DESCRIPTION
Based on discussion about default values from SPC integration into MDN.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/secure-payment-confirmation/pull/265.html" title="Last updated on Dec 7, 2023, 8:56 PM UTC (7656f90)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/secure-payment-confirmation/265/5a27628...7656f90.html" title="Last updated on Dec 7, 2023, 8:56 PM UTC (7656f90)">Diff</a>