### PR TITLE
Clarify that RP can use its own credentials even if extension not specified

### DIFF
--- a/spec.bs
+++ b/spec.bs
@@ -797,10 +797,15 @@ input {{SecurePaymentConfirmationRequest}} |data|, are:
 1. For each |id| in |data|["{{SecurePaymentConfirmationRequest/credentialIds}}"]:
 
     1. Run the [=steps to silently determine if a credential is available for
-        the current device=] and the [=steps to silently determine if a
+        the current device=], passing in
+        |data|["{{SecurePaymentConfirmationRequest/rpId}}"] and |id|.
+	If the result is `false`, remove |id| from
+        |data|["{{SecurePaymentConfirmationRequest/credentialIds}}"].
+    2.  If the |data|["{{SecurePaymentConfirmationRequest/rpId}}"] is
+        not in the current origin, run the [=steps to silently determine if a
         credential is SPC-enabled=], passing in
         |data|["{{SecurePaymentConfirmationRequest/rpId}}"] and |id|. If the
-        result of either of these is `false`, remove |id| from
+        result is `false`, remove |id| from
         |data|["{{SecurePaymentConfirmationRequest/credentialIds}}"].
 
 1. If |data|["{{SecurePaymentConfirmationRequest/credentialIds}}"] is now empty,


### PR DESCRIPTION
Make clear that an RP should be able to use its own credentials even if payment extension not specified.