### PR TITLE
[Spec] Add support for displaying logos from facilitating payment entities

### DIFF
--- a/spec.bs
+++ b/spec.bs
@@ -1037,6 +1037,15 @@ The [=steps to respond to a payment request=] for this payment method, for a giv
     : {{AuthenticationExtensionsPaymentInputs/paymentEntitiesLogos}}
     :: |data|["{{SecurePaymentConfirmationRequest/paymentEntitiesLogos}}"] if
         it is present and non-empty, otherwise omitted.
+
+        Issue: The current version of this specification supports only a single
+        URL per {{PaymentEntityLogo}}, so simply copying and signing the data
+        structure suffices to indicate what was shown to the user. A future
+        version of this specification may add multiple URLs per
+        {{PaymentEntityLogo}} in order to, e.g., natively support dark mode. If
+        this happens, the specification will need to indicate to the [=Relying
+        Party=] which URL was shown for a given {{PaymentEntityLogo}}.
+
     : {{AuthenticationExtensionsPaymentInputs/total}}
     :: |request|.[=payment request details|[[details]]=]["{{PaymentDetailsInit/total}}"]
     : {{AuthenticationExtensionsPaymentInputs/instrument}}


### PR DESCRIPTION
This change adds the ability for the SPC caller to specify a sequence of 'facilitating entity logos', which are intended to be logos from payment entities (e.g., card network or issuer in the credit card space) that can provide context for the authentication to the user. Logos are specified by the caller in a descending order of importance.

In order to avoid constraining individual user agent interface design, the user agent is free to show a subset (including the empty subset) of the input logos, but it must respect the order of importance - that is, it can only show a logo with index j in the list if it is also showing all logos with indices i < j.

This change is intended to be future compatible for a world where we may later add additional information about the logos, including potential rendering hints and accessibility information, but for now constrains itself to the minimal possible support.

See #197

Tasks:

- [x] Chromium bug for implementation - https://crbug.com/417683819
- [ ] WPT tests added/updated - https://github.com/web-platform-tests/wpt/pull/53358


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/secure-payment-confirmation/pull/294.html" title="Last updated on May 23, 2025, 5:22 PM UTC (eaaa777)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/secure-payment-confirmation/294/72eb74e...eaaa777.html" title="Last updated on May 23, 2025, 5:22 PM UTC (eaaa777)">Diff</a>