### PR TITLE
Add wpt tests for browser bound keys and auth another way.

### DIFF
--- a/spec.bs
+++ b/spec.bs
@@ -1106,6 +1106,10 @@ if and how to proceed:
     1. Run the [=user accepts the payment request algorithm=] on the
         {{PaymentRequest}} the user is interacting with.
 
+    <wpt>
+      authentication-auth-another-way.https.html
+    </wpt>
+
 : The user does not wish to proceed with the payment,
 :: Run the [=user aborts the payment request algorithm=] on the
     {{PaymentRequest}} the user is interacting with.

--- a/spec.bs
+++ b/spec.bs
@@ -1365,6 +1365,12 @@ Note: Previously, the `payment` extension allowed for the creation of
 
     1. Before step 13 (creating a {{CollectedClientData}}).
 
+        <wpt>
+          authentication-accepted-bbk-created.https.html
+          authentication-accepted-bbk-per-passkey.https.html
+          authentication-accepted-bbk-reused.https.html
+        </wpt>
+
         1. Let |bbk_allowed_algorithms| be {{AuthenticationExtensionsPaymentInputs/browserBoundPubKeyCredParams}}.
 
         1. If
@@ -1506,6 +1512,11 @@ Note: Previously, the `payment` extension allowed for the creation of
             1. [=map/Set=]
                 {{PublicKeyCredential/[[clientExtensionsResults]]}}[[[#sctn-payment-extension-registration|"payment"]]]
                 to |payment_outputs|.
+
+            <wpt>
+              enrollment-bbk-per-passkey.https.html
+              enrollment-bbk.https.html
+            </wpt>
 
 :  Client extension output
 ::


### PR DESCRIPTION



<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/pejic/secure-payment-confirmation/pull/308.html" title="Last updated on Jul 16, 2025, 12:48 PM UTC (cd36f70)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/secure-payment-confirmation/308/7806432...pejic:cd36f70.html" title="Last updated on Jul 16, 2025, 12:48 PM UTC (cd36f70)">Diff</a>