### PR TITLE
(Editorial) With the closure of issue 65, we can remove note related to PR API

### DIFF
--- a/spec.bs
+++ b/spec.bs
@@ -710,13 +710,6 @@ from the Relying Party on some other unspecified channel. See
   authentication-requires-user-activation.https.html
 </wpt>
 
-NOTE: To quickly support an initial SPC experiment, this API was designed atop
-existing implementations of the Payment Request and Payment Handler APIs. There
-is now general agreement to explore a design of SPC independent of Payment
-Request. We therefore expect (without a concrete timeline) that SPC will move
-away from its Payment Request origins. For developers, this should improve
-feature detection, invocation, and other aspects of the API.
-
 ## Registration in [[payment-method-id]] ## {#sctn-registration-in-payment-method-id}
 
 Add the following to the [=registry of standardized payment methods=] in


### PR DESCRIPTION
At the WPWG call today we closed [issue 65](https://github.com/w3c/secure-payment-confirmation/issues/65) and therefore can remove this informative Note from the spec.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/secure-payment-confirmation/pull/323.html" title="Last updated on Mar 12, 2026, 3:59 PM UTC (724dcde)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/secure-payment-confirmation/323/02f36b5...724dcde.html" title="Last updated on Mar 12, 2026, 3:59 PM UTC (724dcde)">Diff</a>