### PR TITLE
Update from api.csswg.org/bikeshed to spec-generator

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -4,10 +4,11 @@ local: spec.bs
 	bikeshed --die-on=warning spec spec.bs spec.html
 
 spec.html: spec.bs
-	@ (HTTP_STATUS=$$(curl https://api.csswg.org/bikeshed/ \
+	@ (HTTP_STATUS=$$(curl https://www.w3.org/publications/spec-generator/ \
 	                       --output spec.html \
 	                       --write-out "%{http_code}" \
 	                       --header "Accept: text/plain, text/html" \
+	                       -F type=bikeshed-spec \
 	                       -F die-on=warning \
 	                       -F file=@spec.bs) && \
 	[[ "$$HTTP_STATUS" -eq "200" ]]) || ( \


### PR DESCRIPTION
This updates the Makefile to reference spec-generator instead of the discontinued CSSWG Bikeshed service.

I would flag that `make remote` results in an empty `<div data-fill-with="status">`, whereas `make local` does not. This is due to `Local Boilerplate: status yes`, which the `curl` command in the Makefile does not account for since it only uploads `index.bs`, so this seems like it would have been a pre-existing issue.