### PR TITLE
Disallow webauthn extensions in cross-origin authentication ceremonies

### DIFF
--- a/spec.bs
+++ b/spec.bs
@@ -821,8 +821,7 @@ members:
 
         NOTE: A third-party SPC call will throw if this dictionary is
         non-empty, to avoid attacks on [=Relying Party=] extensions that can
-        store private data. See
-        [[#sctn-security-restricted-webauthn-extensions]].
+        store private data. See [[#sctn-security-webauthn-extensions]].
 
     : {{SecurePaymentConfirmationRequest/browserBoundPubKeyCredParams}}
     :: The list of allowed types of credential restricting the types of
@@ -2341,7 +2340,7 @@ an unauthorized payment using Secure Payment Confirmation credentials
         if an attacker attempts to sit between the user and a valid merchant
         site and forward the assertion.
 
-### Restricted WebAuthn Extensions ### {#sctn-security-restricted-webauthn-extensions}
+### WebAuthn Extensions Only Allowed for the Relying Party ### {#sctn-security-webauthn-extensions}
 
 WebAuthn allows for [=authentication extensions=] to be used during an
 authentication ceremony. Some extensions can be used to store or retrieve data

--- a/spec.bs
+++ b/spec.bs
@@ -80,6 +80,7 @@ spec: web-authn; urlPrefix: https://w3c.github.io/webauthn/
         text: create credential async loop; url: CreateCred-async-loop
         text: credentialPublicKey; url: authdata-attestedcredentialdata-credentialpublickey
         text: base64url encoding; url: base64url-encoding
+        text: largeBlob; url: largeblob
 
 spec: webdriver; urlPrefix: https://w3c.github.io/webdriver/
     type: dfn
@@ -816,7 +817,7 @@ members:
     :: Any [=WebAuthn extensions=] that should be used for the passed
         credential(s). The caller does not need to specify the
         [[#sctn-payment-extension-registration| payment extension]]; it is added
-        automatically.
+        automatically. For a third-party SPC call, this list MUST be empty.
 
     : {{SecurePaymentConfirmationRequest/browserBoundPubKeyCredParams}}
     :: The list of allowed types of credential restricting the types of
@@ -1081,6 +1082,11 @@ input {{PaymentRequest}} |request| and {{SecurePaymentConfirmationRequest}} |dat
 
         1. If |logo|["{{PaymentEntityLogo/label}}"] is empty, throw a
             {{TypeError}}.
+
+1. If |data|["{{SecurePaymentConfirmationRequest/extensions}}"] [=map/exists=]
+    and [=map/is not empty=], and
+    |data|["{{SecurePaymentConfirmationRequest/rpId}}"] is not the [=origin=] of
+    the [=relevant settings object=] of |request|, throw a {{TypeError}}.
 
 1. If |data|["{{SecurePaymentConfirmationRequest/locale}}"] [=map/exists=] and
     [=list/is not empty=]
@@ -2329,6 +2335,28 @@ an unauthorized payment using Secure Payment Confirmation credentials
     * An incorrect {{CollectedClientData}}["{{CollectedClientData/origin}}"],
         if an attacker attempts to sit between the user and a valid merchant
         site and forward the assertion.
+
+### Restricted WebAuthn Extensions ### {#sctn-security-restricted-webauthn-extensions}
+
+WebAuthn allows for [=authentication extensions=] to be used during an
+authentication ceremony. Some extensions can be used to store or retrieve data
+(on the authenticator) that is sensitive to the [=Relying Party=].
+
+In a Secure Payment Confirmation authentication ceremony, a third party (the
+caller) can initiate the ceremony for a credential owned by a different
+[=Relying Party=]. If the caller were allowed to specify arbitrary WebAuthn
+extensions, they might be able to access sensitive data belonging to the
+[=Relying Party=] that the [=Relying Party=] did not intend to share with the
+caller.
+
+For example, the [=largeBlob=] extension allows for storing and retrieving
+large amounts of data. If an attacker could initiate an SPC ceremony with the
+`largeBlob` extension, they might be able to read data that the [=Relying
+Party=] had stored there, assuming the user authorizes the ceremony.
+
+To mitigate this risk, Secure Payment Confirmation disallows the use of
+WebAuthn extensions in cross-origin authentication ceremonies; they are only
+allowed when the caller is the [=Relying Party=].
 
 ## Merchant-supplied authentication data ## {#sctn-security-merchant-data}
 

--- a/spec.bs
+++ b/spec.bs
@@ -817,7 +817,12 @@ members:
     :: Any [=WebAuthn extensions=] that should be used for the passed
         credential(s). The caller does not need to specify the
         [[#sctn-payment-extension-registration| payment extension]]; it is added
-        automatically. For a third-party SPC call, the dictionary MUST be empty.
+        automatically.
+
+        NOTE: A third-party SPC call will throw if this dictionary is
+        non-empty, to avoid attacks on [=Relying Party=] extensions that can
+        store private data. See
+        [[#sctn-security-restricted-webauthn-extensions]].
 
     : {{SecurePaymentConfirmationRequest/browserBoundPubKeyCredParams}}
     :: The list of allowed types of credential restricting the types of

--- a/spec.bs
+++ b/spec.bs
@@ -817,7 +817,7 @@ members:
     :: Any [=WebAuthn extensions=] that should be used for the passed
         credential(s). The caller does not need to specify the
         [[#sctn-payment-extension-registration| payment extension]]; it is added
-        automatically. For a third-party SPC call, this list MUST be empty.
+        automatically. For a third-party SPC call, the dictionary MUST be empty.
 
     : {{SecurePaymentConfirmationRequest/browserBoundPubKeyCredParams}}
     :: The list of allowed types of credential restricting the types of


### PR DESCRIPTION
This reverts commit 31cdf436f43db0573c9466dd46e5d126be73484b, re-landing a new version of 31cdf436f43db0573c9466dd46e5d126be73484b. Instead of an allowlist, this version of the change just bans all extensions in cross-origin ceremonies.

Fixes #326


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/secure-payment-confirmation/pull/332.html" title="Last updated on Jun 3, 2026, 2:27 PM UTC (0d75a25)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/secure-payment-confirmation/332/3c2d9f8...0d75a25.html" title="Last updated on Jun 3, 2026, 2:27 PM UTC (0d75a25)">Diff</a>